### PR TITLE
Introduce bpmn read/write with initial BPMNDiagram generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Build
 target/
+out/
 
 # IDE
 /.idea/

--- a/README.md
+++ b/README.md
@@ -4,8 +4,12 @@ Tools for generating missing BPMNDiagram elements in BPMN files
 
 Plan work for the 1st implementation
 - could be based on https://www.researchgate.net/publication/221542866_A_Simple_Algorithm_for_Automatic_Layout_of_BPMN_Processes
-- will be implemented in `Java`. If it works, `javascript` and `R` implementations will be done
+- will be implemented in `Java`. If it works, `javascript`/`typescript` and `R` implementations will be done
 
+
+## Implementations
+
+- [java](java/README.md)
 
 ## Existing alternatives
 

--- a/java/README.md
+++ b/java/README.md
@@ -1,0 +1,13 @@
+# BPMN Layout Generator Java Implementation
+
+## Requirements
+
+> JDK 11 only
+>
+
+## Build
+
+The project bundle a Maven Wrapper, so just run
+``` bash
+./mvnw package
+```

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -26,8 +26,9 @@
   </dependencies>
 
   <build>
-    <pluginManagement><!-- lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
+    <pluginManagement>
       <plugins>
+        <!-- Maven Standard Plugins: lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
         <plugin>
           <artifactId>maven-clean-plugin</artifactId>
           <version>3.1.0</version>
@@ -56,7 +57,31 @@
           <artifactId>maven-deploy-plugin</artifactId>
           <version>2.8.2</version>
         </plugin>
+        <!-- 3rd party plugins -->
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>jaxb2-maven-plugin</artifactId>
+          <version>2.5.0</version>
+        </plugin>
       </plugins>
     </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>jaxb2-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>xjc</id>
+            <goals>
+              <goal>xjc</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <!-- The package of your generated sources -->
+          <packageName>io.process.analytics.tools.bpmn.generator.model</packageName>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
 </project>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -13,6 +13,7 @@
         <maven.compiler.target>11</maven.compiler.target>
 
         <jaxb.version>2.3.1</jaxb.version>
+        <junit.version>5.6.2</junit.version>
     </properties>
 
     <dependencies>
@@ -35,10 +36,15 @@
         </dependency>
         <!-- test -->
         <dependency>
-            <!-- Move to JUnit 5 -->
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -103,7 +103,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <packageName>io.process.analytics.tools.bpmn.generator.internal.model</packageName>
+                    <packageName>io.process.analytics.tools.bpmn.generator.internal.generated.model</packageName>
                     <locale>en</locale>
                     <!--                    <addGeneratedAnnotation>true</addGeneratedAnnotation>-->
                 </configuration>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -23,12 +23,12 @@
             <version>${jaxb.version}</version>
         </dependency>
         <!-- Runtime -->
-<!--        <dependency>-->
-<!--            <groupId>org.glassfish.jaxb</groupId>-->
-<!--            <artifactId>jaxb-runtime</artifactId>-->
-<!--            <version>${jaxb.version}</version>-->
-<!--            <scope></scope>-->
-<!--        </dependency>-->
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>${jaxb.version}</version>
+            <scope>runtime</scope>
+        </dependency>
         <!-- test -->
         <dependency>
             <!-- Move to JUnit 5 -->
@@ -94,7 +94,7 @@
                 </executions>
                 <configuration>
                     <packageName>io.process.analytics.tools.bpmn.generator.internal.model</packageName>
-                    <!--          <addGeneratedAnnotation>true</addGeneratedAnnotation>-->
+<!--                    <addGeneratedAnnotation>true</addGeneratedAnnotation>-->
                 </configuration>
             </plugin>
             <plugin>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -16,13 +16,17 @@
     </properties>
 
     <dependencies>
-        <!-- API -->
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <version>1.18.12</version>
+            <scope>provided</scope>
+        </dependency>
         <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
             <version>${jaxb.version}</version>
         </dependency>
-        <!-- Runtime -->
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>
@@ -95,7 +99,7 @@
                 <configuration>
                     <packageName>io.process.analytics.tools.bpmn.generator.internal.model</packageName>
                     <locale>en</locale>
-<!--                    <addGeneratedAnnotation>true</addGeneratedAnnotation>-->
+                    <!--                    <addGeneratedAnnotation>true</addGeneratedAnnotation>-->
                 </configuration>
             </plugin>
             <plugin>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -1,87 +1,121 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-  <modelVersion>4.0.0</modelVersion>
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-  <groupId>io.process.analytics.tools.bpmn</groupId>
-  <artifactId>bpmn-layout-generator</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+    <groupId>io.process.analytics.tools.bpmn</groupId>
+    <artifactId>bpmn-layout-generator</artifactId>
+    <version>0.1.0-SNAPSHOT</version>
 
-  <name>bpmn-layout-generator</name>
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
 
-  <properties>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
-  </properties>
+        <jaxb.version>2.3.1</jaxb.version>
+    </properties>
 
-  <dependencies>
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.11</version>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
+    <dependencies>
+        <!-- API -->
+        <dependency>
+            <groupId>javax.xml.bind</groupId>
+            <artifactId>jaxb-api</artifactId>
+            <version>${jaxb.version}</version>
+        </dependency>
+        <!-- Runtime -->
+<!--        <dependency>-->
+<!--            <groupId>org.glassfish.jaxb</groupId>-->
+<!--            <artifactId>jaxb-runtime</artifactId>-->
+<!--            <version>${jaxb.version}</version>-->
+<!--            <scope></scope>-->
+<!--        </dependency>-->
+        <!-- test -->
+        <dependency>
+            <!-- Move to JUnit 5 -->
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.14.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
-  <build>
-    <pluginManagement>
-      <plugins>
-        <!-- Maven Standard Plugins: lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
-        <plugin>
-          <artifactId>maven-clean-plugin</artifactId>
-          <version>3.1.0</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-resources-plugin</artifactId>
-          <version>3.0.2</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.8.0</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.22.1</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-jar-plugin</artifactId>
-          <version>3.0.2</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-install-plugin</artifactId>
-          <version>2.5.2</version>
-        </plugin>
-        <plugin>
-          <artifactId>maven-deploy-plugin</artifactId>
-          <version>2.8.2</version>
-        </plugin>
-        <!-- 3rd party plugins -->
-        <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>jaxb2-maven-plugin</artifactId>
-          <version>2.5.0</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-    <plugins>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>jaxb2-maven-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>xjc</id>
-            <goals>
-              <goal>xjc</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <!-- The package of your generated sources -->
-          <packageName>io.process.analytics.tools.bpmn.generator.model</packageName>
-        </configuration>
-      </plugin>
-    </plugins>
-  </build>
+    <build>
+        <pluginManagement>
+            <plugins>
+                <!-- Maven Standard Plugins: lock down plugins versions to avoid using Maven defaults (may be moved to parent pom) -->
+                <plugin>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>3.0.2</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.8.0</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.22.1</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.0.2</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>2.5.2</version>
+                </plugin>
+                <plugin>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>2.8.2</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>jaxb2-maven-plugin</artifactId>
+                <version>2.5.0</version>
+                <executions>
+                    <execution>
+                        <id>xjc</id>
+                        <goals>
+                            <goal>xjc</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <packageName>io.process.analytics.tools.bpmn.generator.internal.model</packageName>
+                    <!--          <addGeneratedAnnotation>true</addGeneratedAnnotation>-->
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>add-source</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>add-source</goal>
+                        </goals>
+                        <configuration>
+                            <sources>
+                                <source>${project.build.directory}/generate-sources/jaxb</source>
+                            </sources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -94,6 +94,7 @@
                 </executions>
                 <configuration>
                     <packageName>io.process.analytics.tools.bpmn.generator.internal.model</packageName>
+                    <locale>en</locale>
 <!--                    <addGeneratedAnnotation>true</addGeneratedAnnotation>-->
                 </configuration>
             </plugin>

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/App.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/App.java
@@ -20,7 +20,7 @@ import java.io.File;
 
 import io.process.analytics.tools.bpmn.generator.internal.BPMNDiagramRichBuilder;
 import io.process.analytics.tools.bpmn.generator.internal.BpmnInOut;
-import io.process.analytics.tools.bpmn.generator.internal.model.TDefinitions;
+import io.process.analytics.tools.bpmn.generator.internal.generated.model.TDefinitions;
 
 public class App {
 

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/App.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/App.java
@@ -18,16 +18,26 @@ import static io.process.analytics.tools.bpmn.generator.internal.BpmnInOut.defau
 
 import java.io.File;
 
+import io.process.analytics.tools.bpmn.generator.internal.BPMNDiagramRichBuilder;
+import io.process.analytics.tools.bpmn.generator.internal.BpmnInOut;
 import io.process.analytics.tools.bpmn.generator.internal.model.TDefinitions;
 
 public class App {
 
     public static void main(String[] args) {
         validate(args);
-        String bpmnFilePath = args[0];
-        log("Loading bpmn file: " + bpmnFilePath);
-        TDefinitions tDefinitions = defaultBpmnInOut().readFromBpmn(new File(bpmnFilePath));
+        String inputBpmnFilePath = args[0];
+        log("Loading bpmn file: " + inputBpmnFilePath);
+        BpmnInOut bpmnInOut = defaultBpmnInOut();
+        TDefinitions tDefinitions = bpmnInOut.readFromBpmn(new File(inputBpmnFilePath));
         log("Loaded " + tDefinitions);
+
+        log("Building bpmn diagram elements");
+        TDefinitions builtDefinitions = new BPMNDiagramRichBuilder(tDefinitions).build();
+        log("Bpmn diagram elements have been built");
+        File outputBpmnFile = new File(args[1]);
+        bpmnInOut.writeToBpmnFile(builtDefinitions, outputBpmnFile);
+        log("New file with bpmn diagram generated to " + outputBpmnFile.getAbsolutePath());
     }
 
     private static void validate(String[] args) {

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/App.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/App.java
@@ -14,10 +14,11 @@
  */
 package io.process.analytics.tools.bpmn.generator;
 
-import io.process.analytics.tools.bpmn.generator.internal.XmlParser;
-import io.process.analytics.tools.bpmn.generator.internal.model.TDefinitions;
+import static io.process.analytics.tools.bpmn.generator.internal.BpmnInOut.defaultBpmnInOut;
 
 import java.io.File;
+
+import io.process.analytics.tools.bpmn.generator.internal.model.TDefinitions;
 
 public class App {
 
@@ -25,8 +26,7 @@ public class App {
         validate(args);
         String bpmnFilePath = args[0];
         log("Loading bpmn file: " + bpmnFilePath);
-        BpmnInOut bpmnInOut = new BpmnInOut(new XmlParser());
-        TDefinitions tDefinitions = bpmnInOut.readFromBpmn(new File(bpmnFilePath));
+        TDefinitions tDefinitions = defaultBpmnInOut().readFromBpmn(new File(bpmnFilePath));
         log("Loaded " + tDefinitions);
     }
 

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/App.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/App.java
@@ -1,6 +1,5 @@
 /*
  * Copyright 2020 Bonitasoft S.A.
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -15,8 +14,30 @@
  */
 package io.process.analytics.tools.bpmn.generator;
 
+import io.process.analytics.tools.bpmn.generator.internal.XmlParser;
+import io.process.analytics.tools.bpmn.generator.internal.model.TDefinitions;
+
+import java.io.File;
+
 public class App {
+
     public static void main(String[] args) {
-        System.out.println("Hello World!");
+        validate(args);
+        String bpmnFilePath = args[0];
+        log("Loading bpmn file: " + bpmnFilePath);
+        BpmnInOut bpmnInOut = new BpmnInOut(new XmlParser());
+        TDefinitions tDefinitions = bpmnInOut.readFromBpmn(new File(bpmnFilePath));
+        log("Loaded " + tDefinitions);
     }
+
+    private static void validate(String[] args) {
+        if (args.length <= 1) {
+            throw new IllegalArgumentException("You must pass at least 2 arguments.");
+        }
+    }
+
+    private static void log(String message) {
+        System.out.println(message);
+    }
+
 }

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/BpmnInOut.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/BpmnInOut.java
@@ -30,14 +30,14 @@ public class BpmnInOut {
         this.xmlParser = xmlParser;
     }
 
-    public void readFromBpmn(String xml) {
-        TDefinitions unmarshall = xmlParser.unmarshall(xml);
+    public TDefinitions readFromBpmn(String xml) {
+        return xmlParser.unmarshall(xml);
     }
 
-    public void readFromBpmn(File bpmn) {
+    public TDefinitions readFromBpmn(File bpmn) {
         try {
             String xml = Files.readString(bpmn.toPath());
-            readFromBpmn(xml);
+            return readFromBpmn(xml);
         } catch (IOException e) {
             throw new RuntimeException("Error while reading file " + bpmn.getName(), e);
         }

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/BpmnInOut.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/BpmnInOut.java
@@ -16,6 +16,7 @@
 package io.process.analytics.tools.bpmn.generator;
 
 import io.process.analytics.tools.bpmn.generator.internal.XmlParser;
+import io.process.analytics.tools.bpmn.generator.internal.model.TDefinitions;
 
 import java.io.File;
 import java.io.IOException;
@@ -30,7 +31,7 @@ public class BpmnInOut {
     }
 
     public void readFromBpmn(String xml) {
-        xmlParser.unmarshall(xml);
+        TDefinitions unmarshall = xmlParser.unmarshall(xml);
     }
 
     public void readFromBpmn(File bpmn) {

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/BpmnInOut.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/BpmnInOut.java
@@ -1,0 +1,22 @@
+package io.process.analytics.tools.bpmn.generator;
+
+import io.process.analytics.tools.bpmn.generator.internal.XmlParser;
+
+public class BpmnInOut {
+
+    private final XmlParser xmlParser;
+
+    public BpmnInOut(XmlParser xmlParser) {
+        this.xmlParser = xmlParser;
+    }
+
+    public void readFromBpmn(String xml) {
+
+    }
+
+    public void writeToBpmn() {
+
+    }
+
+
+}

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/BpmnInOut.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/BpmnInOut.java
@@ -1,6 +1,25 @@
+/*
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.process.analytics.tools.bpmn.generator;
 
 import io.process.analytics.tools.bpmn.generator.internal.XmlParser;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 
 public class BpmnInOut {
 
@@ -11,12 +30,20 @@ public class BpmnInOut {
     }
 
     public void readFromBpmn(String xml) {
-
+        xmlParser.unmarshall(xml);
     }
 
-    public void writeToBpmn() {
-
+    public void readFromBpmn(File bpmn) {
+        try {
+            String xml = Files.readString(bpmn.toPath());
+            readFromBpmn(xml);
+        } catch (IOException e) {
+            throw new RuntimeException("Error while reading file " + bpmn.getName(), e);
+        }
     }
 
+//    public void writeToBpmn() {
+//
+//    }
 
 }

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/BPMNDiagramRichBuilder.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/BPMNDiagramRichBuilder.java
@@ -15,7 +15,7 @@
  */
 package io.process.analytics.tools.bpmn.generator.internal;
 
-import io.process.analytics.tools.bpmn.generator.internal.model.*;
+import io.process.analytics.tools.bpmn.generator.internal.generated.model.*;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/BPMNDiagramRichBuilder.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/BPMNDiagramRichBuilder.java
@@ -5,6 +5,7 @@ import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
 import javax.xml.namespace.QName;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -16,6 +17,7 @@ public class BPMNDiagramRichBuilder {
     @NonNull
     private final TDefinitions definitions;
 
+    // TODO make this internal and set the diagram to a field of this class
     public BPMNDiagram initializeBPMNDiagram() {
         BPMNDiagram bpmnDiagram = new BPMNDiagram();
         bpmnDiagram.setId("BPMNDiagram_1");
@@ -26,6 +28,22 @@ public class BPMNDiagramRichBuilder {
         putBpmnElement(bpmnPlane, computeBPMNPlaneBpmnElementId());
 
         return bpmnDiagram;
+    }
+
+    public void addNode() {
+        // TODO add node as bpmn shape to the initialized bpmn diagram
+    }
+
+    public void addEdge() {
+        // TODO add edge as bpmn edge to the initialized bpmn diagram
+    }
+
+    public TDefinitions build() {
+        // TODO it should be better to clone the initial definitions
+        List<BPMNDiagram> diagrams = definitions.getBPMNDiagram();
+        diagrams.clear();
+        diagrams.add(initializeBPMNDiagram());
+        return definitions;
     }
 
     // copied from the generated ObjectFactory

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/BPMNDiagramRichBuilder.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/BPMNDiagramRichBuilder.java
@@ -1,0 +1,49 @@
+package io.process.analytics.tools.bpmn.generator.internal;
+
+import io.process.analytics.tools.bpmn.generator.internal.model.BPMNDiagram;
+import io.process.analytics.tools.bpmn.generator.internal.model.BPMNPlane;
+import io.process.analytics.tools.bpmn.generator.internal.model.TCollaboration;
+import io.process.analytics.tools.bpmn.generator.internal.model.TDefinitions;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+
+import javax.xml.namespace.QName;
+import java.util.Optional;
+
+/**
+ * Helper to build a BPMNDiagram based on existing TDefinitions semantic part
+ */
+@RequiredArgsConstructor
+public class BPMNDiagramRichBuilder {
+
+    @NonNull
+    private final TDefinitions definitions;
+
+    private void createBPMNDiagram() {
+
+        BPMNDiagram bpmnDiagram = new BPMNDiagram();
+        bpmnDiagram.setId("BPMNDiagram_1");
+
+        BPMNPlane bpmnPlane = new BPMNPlane();
+        bpmnPlane.setId("BPMNPlane_1");
+        //        QName bpmnElement = bpmnPlane.getBpmnElement()
+        //        bpmnElement.getid
+
+    }
+
+    // bpmn element value depends on semantic collaboration existence
+    private String computeBPMNPlaneBpmnElementId() {
+        Semantic semantic = new Semantic(definitions);
+        Optional<TCollaboration> collaboration = semantic.getCollaboration();
+        // TODO refactor
+        if (collaboration.isPresent()) {
+            String bpmnElementId = collaboration.get().getId();
+
+        } else {
+            // get the single process
+
+        }
+        return null;
+    }
+
+}

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/BPMNDiagramRichBuilder.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/BPMNDiagramRichBuilder.java
@@ -1,9 +1,6 @@
 package io.process.analytics.tools.bpmn.generator.internal;
 
-import io.process.analytics.tools.bpmn.generator.internal.model.BPMNDiagram;
-import io.process.analytics.tools.bpmn.generator.internal.model.BPMNPlane;
-import io.process.analytics.tools.bpmn.generator.internal.model.TCollaboration;
-import io.process.analytics.tools.bpmn.generator.internal.model.TDefinitions;
+import io.process.analytics.tools.bpmn.generator.internal.model.*;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
@@ -19,31 +16,48 @@ public class BPMNDiagramRichBuilder {
     @NonNull
     private final TDefinitions definitions;
 
-    private void createBPMNDiagram() {
-
+    public BPMNDiagram initializeBPMNDiagram() {
         BPMNDiagram bpmnDiagram = new BPMNDiagram();
         bpmnDiagram.setId("BPMNDiagram_1");
 
         BPMNPlane bpmnPlane = new BPMNPlane();
+        bpmnDiagram.setBPMNPlane(bpmnPlane);
         bpmnPlane.setId("BPMNPlane_1");
-        //        QName bpmnElement = bpmnPlane.getBpmnElement()
-        //        bpmnElement.getid
+        putBpmnElement(bpmnPlane, computeBPMNPlaneBpmnElementId());
 
+        return bpmnDiagram;
     }
 
+    // copied from the generated ObjectFactory
+    private final static QName _Process_QNAME = new QName("http://www.omg.org/spec/BPMN/20100524/MODEL", "process");
+    private final static QName _Collaboration_QNAME = new QName("http://www.omg.org/spec/BPMN/20100524/MODEL", "collaboration");
+
+    // TODO we need to know if this is a process or a collaboration to set the actual qname
+    private void putBpmnElement(BPMNPlane bpmnPlane, BpmnElementRef bpmnElementRef) {
+        QName qName = bpmnElementRef.qName;
+        bpmnPlane.setBpmnElement(qName);
+        bpmnPlane.getOtherAttributes().put(qName, bpmnElementRef.ref);
+    }
+
+    // TODO move to the Semantic class?
     // bpmn element value depends on semantic collaboration existence
-    private String computeBPMNPlaneBpmnElementId() {
-        Semantic semantic = new Semantic(definitions);
+    // if no collaboration, there is a single process, so use its id
+    private BpmnElementRef computeBPMNPlaneBpmnElementId() {
+        final Semantic semantic = new Semantic(definitions);
         Optional<TCollaboration> collaboration = semantic.getCollaboration();
-        // TODO refactor
-        if (collaboration.isPresent()) {
-            String bpmnElementId = collaboration.get().getId();
+        // TODO empty processes is supposed to be managed by Semantic
+        return collaboration.map(TBaseElement::getId)
+                .map(id -> new BpmnElementRef(_Collaboration_QNAME, id))
+                .orElseGet(() -> new BpmnElementRef(_Process_QNAME, semantic.getProcesses().get(0).getId()));
+    }
 
-        } else {
-            // get the single process
+    @RequiredArgsConstructor
+    private static class BpmnElementRef {
 
-        }
-        return null;
+        @NonNull
+        private final QName qName;
+        @NonNull
+        private final String ref;
     }
 
 }

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/BPMNDiagramRichBuilder.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/BPMNDiagramRichBuilder.java
@@ -19,6 +19,7 @@ import io.process.analytics.tools.bpmn.generator.internal.model.*;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 
+import javax.xml.XMLConstants;
 import javax.xml.namespace.QName;
 import java.util.List;
 import java.util.Optional;
@@ -61,36 +62,21 @@ public class BPMNDiagramRichBuilder {
         return definitions;
     }
 
-    // copied from the generated ObjectFactory
-    private final static QName _Process_QNAME = new QName("http://www.omg.org/spec/BPMN/20100524/MODEL", "process");
-    private final static QName _Collaboration_QNAME = new QName("http://www.omg.org/spec/BPMN/20100524/MODEL", "collaboration");
-
     // TODO we need to know if this is a process or a collaboration to set the actual qname
-    private void putBpmnElement(BPMNPlane bpmnPlane, BpmnElementRef bpmnElementRef) {
-        QName qName = bpmnElementRef.qName;
+    private void putBpmnElement(BPMNPlane bpmnPlane, String bpmnElementRef) {
+        QName qName = new QName(XMLConstants.NULL_NS_URI, bpmnElementRef);
         bpmnPlane.setBpmnElement(qName);
-        bpmnPlane.getOtherAttributes().put(qName, bpmnElementRef.ref);
     }
 
     // TODO move to the Semantic class?
     // bpmn element value depends on semantic collaboration existence
     // if no collaboration, there is a single process, so use its id
-    private BpmnElementRef computeBPMNPlaneBpmnElementId() {
+    private String computeBPMNPlaneBpmnElementId() {
         final Semantic semantic = new Semantic(definitions);
         Optional<TCollaboration> collaboration = semantic.getCollaboration();
         // TODO empty processes is supposed to be managed by Semantic
         return collaboration.map(TBaseElement::getId)
-                .map(id -> new BpmnElementRef(_Collaboration_QNAME, id))
-                .orElseGet(() -> new BpmnElementRef(_Process_QNAME, semantic.getProcesses().get(0).getId()));
-    }
-
-    @RequiredArgsConstructor
-    private static class BpmnElementRef {
-
-        @NonNull
-        private final QName qName;
-        @NonNull
-        private final String ref;
+                .orElseGet(() -> semantic.getProcesses().get(0).getId());
     }
 
 }

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/BPMNDiagramRichBuilder.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/BPMNDiagramRichBuilder.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.process.analytics.tools.bpmn.generator.internal;
 
 import io.process.analytics.tools.bpmn.generator.internal.model.*;

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/BpmnInOut.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/BpmnInOut.java
@@ -15,11 +15,11 @@
  */
 package io.process.analytics.tools.bpmn.generator.internal;
 
-import io.process.analytics.tools.bpmn.generator.internal.model.TDefinitions;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+
+import io.process.analytics.tools.bpmn.generator.internal.generated.model.TDefinitions;
 
 public class BpmnInOut {
 

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/BpmnInOut.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/BpmnInOut.java
@@ -47,8 +47,11 @@ public class BpmnInOut {
     }
 
 
-//    public void writeToBpmn() {
-//
-//    }
+    public void writeToBpmnFile(TDefinitions definitions, File file) {
+        // TODO file/folder creation
+        file.getParentFile().mkdirs();
+
+        xmlParser.marshal(definitions, file);
+    }
 
 }

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/BpmnInOut.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/BpmnInOut.java
@@ -13,9 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.process.analytics.tools.bpmn.generator;
+package io.process.analytics.tools.bpmn.generator.internal;
 
-import io.process.analytics.tools.bpmn.generator.internal.XmlParser;
 import io.process.analytics.tools.bpmn.generator.internal.model.TDefinitions;
 
 import java.io.File;
@@ -25,6 +24,10 @@ import java.nio.file.Files;
 public class BpmnInOut {
 
     private final XmlParser xmlParser;
+
+    public static BpmnInOut defaultBpmnInOut() {
+        return new BpmnInOut(new XmlParser());
+    }
 
     public BpmnInOut(XmlParser xmlParser) {
         this.xmlParser = xmlParser;
@@ -42,6 +45,7 @@ public class BpmnInOut {
             throw new RuntimeException("Error while reading file " + bpmn.getName(), e);
         }
     }
+
 
 //    public void writeToBpmn() {
 //

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/Semantic.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/Semantic.java
@@ -15,11 +15,8 @@
  */
 package io.process.analytics.tools.bpmn.generator.internal;
 
-import io.process.analytics.tools.bpmn.generator.internal.model.TCollaboration;
-import io.process.analytics.tools.bpmn.generator.internal.model.TDefinitions;
-import io.process.analytics.tools.bpmn.generator.internal.model.TParticipant;
-import io.process.analytics.tools.bpmn.generator.internal.model.TProcess;
-import lombok.Getter;
+import io.process.analytics.tools.bpmn.generator.internal.model.*;
+import lombok.*;
 
 import javax.xml.bind.JAXBElement;
 import java.util.Collections;
@@ -30,13 +27,12 @@ import java.util.stream.Collectors;
 /**
  * Helper to access to the BPMN semantic part
  */
+@RequiredArgsConstructor
 public class Semantic {
 
+    @NonNull
+    @Getter
     private final TDefinitions definitions;
-
-    public Semantic(TDefinitions definitions) {
-        this.definitions = definitions;
-    }
 
     public List<TParticipant> getParticipants() {
         List<TCollaboration> collaborations = definitions.getRootElement().stream()
@@ -45,19 +41,12 @@ public class Semantic {
                 .map(o -> (TCollaboration) o)
                 .collect(Collectors.toList());
         // TODO check at most 1
-//        if (collaborations.isEmpty()) {
-//            return Collections.emptyList();
-//        }
-//        return collaborations.get(0).getParticipant();
+        //        if (collaborations.isEmpty()) {
+        //            return Collections.emptyList();
+        //        }
+        //        return collaborations.get(0).getParticipant();
         return Optional.of(collaborations).map(list -> list.get(0).getParticipant())
                 .orElseGet(Collections::emptyList);
     }
-
-    @Getter
-    private List<TProcess> process;
-
-    @Getter
-    private TCollaboration collaboration;
-
 
 }

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/Semantic.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/Semantic.java
@@ -35,18 +35,24 @@ public class Semantic {
     private final TDefinitions definitions;
 
     public List<TParticipant> getParticipants() {
+        return getCollaboration()
+                .map(TCollaboration::getParticipant)
+                .orElseGet(Collections::emptyList);
+    }
+
+    public Optional<TCollaboration> getCollaboration() {
         List<TCollaboration> collaborations = definitions.getRootElement().stream()
                 .map(JAXBElement::getValue)
                 .filter(TCollaboration.class::isInstance)
                 .map(o -> (TCollaboration) o)
                 .collect(Collectors.toList());
-        // TODO check at most 1
-        //        if (collaborations.isEmpty()) {
-        //            return Collections.emptyList();
-        //        }
-        //        return collaborations.get(0).getParticipant();
-        return Optional.of(collaborations).map(list -> list.get(0).getParticipant())
-                .orElseGet(Collections::emptyList);
+
+        // TODO check at most 1 otherwise error
+        // TODO refactor into a more functional way
+        if (collaborations.isEmpty()) {
+            return Optional.empty();
+        }
+        return Optional.of(collaborations.get(0));
     }
 
 }

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/Semantic.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/Semantic.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.process.analytics.tools.bpmn.generator.internal;
+
+import io.process.analytics.tools.bpmn.generator.internal.model.TCollaboration;
+import io.process.analytics.tools.bpmn.generator.internal.model.TDefinitions;
+import io.process.analytics.tools.bpmn.generator.internal.model.TParticipant;
+import io.process.analytics.tools.bpmn.generator.internal.model.TProcess;
+import lombok.Getter;
+
+import javax.xml.bind.JAXBElement;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Helper to access to the BPMN semantic part
+ */
+public class Semantic {
+
+    private final TDefinitions definitions;
+
+    public Semantic(TDefinitions definitions) {
+        this.definitions = definitions;
+    }
+
+    public List<TParticipant> getParticipants() {
+        List<TCollaboration> collaborations = definitions.getRootElement().stream()
+                .map(JAXBElement::getValue)
+                .filter(TCollaboration.class::isInstance)
+                .map(o -> (TCollaboration) o)
+                .collect(Collectors.toList());
+        // TODO check at most 1
+//        if (collaborations.isEmpty()) {
+//            return Collections.emptyList();
+//        }
+//        return collaborations.get(0).getParticipant();
+        return Optional.of(collaborations).map(list -> list.get(0).getParticipant())
+                .orElseGet(Collections::emptyList);
+    }
+
+    @Getter
+    private List<TProcess> process;
+
+    @Getter
+    private TCollaboration collaboration;
+
+
+}

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/Semantic.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/Semantic.java
@@ -55,4 +55,13 @@ public class Semantic {
         return Optional.of(collaborations.get(0));
     }
 
+    public List<TProcess> getProcesses() {
+        // TODO manage no process (should not occurred)
+        return definitions.getRootElement().stream()
+                .map(JAXBElement::getValue)
+                .filter(TProcess.class::isInstance)
+                .map(o -> (TProcess) o)
+                .collect(Collectors.toList());
+    }
+
 }

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/Semantic.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/Semantic.java
@@ -15,14 +15,20 @@
  */
 package io.process.analytics.tools.bpmn.generator.internal;
 
-import io.process.analytics.tools.bpmn.generator.internal.model.*;
-import lombok.*;
-
-import javax.xml.bind.JAXBElement;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+
+import javax.xml.bind.JAXBElement;
+
+import io.process.analytics.tools.bpmn.generator.internal.generated.model.TCollaboration;
+import io.process.analytics.tools.bpmn.generator.internal.generated.model.TDefinitions;
+import io.process.analytics.tools.bpmn.generator.internal.generated.model.TParticipant;
+import io.process.analytics.tools.bpmn.generator.internal.generated.model.TProcess;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
 
 /**
  * Helper to access to the BPMN semantic part

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/XmlParser.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/XmlParser.java
@@ -18,7 +18,9 @@ package io.process.analytics.tools.bpmn.generator.internal;
 import io.process.analytics.tools.bpmn.generator.internal.model.TDefinitions;
 
 import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBElement;
 import javax.xml.bind.JAXBException;
+import javax.xml.transform.stream.StreamSource;
 import java.io.StringReader;
 
 public class XmlParser {
@@ -42,7 +44,9 @@ public class XmlParser {
 
     public TDefinitions unmarshall(String xml) {
         try {
-            return (TDefinitions) context.createUnmarshaller().unmarshal(new StringReader(xml));
+            StreamSource source = new StreamSource(new StringReader(xml));
+            JAXBElement<TDefinitions> root = context.createUnmarshaller().unmarshal(source, TDefinitions.class);
+            return root.getValue();
         } catch (JAXBException e) {
             throw new RuntimeException("Unable to marshal", e);
         }

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/XmlParser.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/XmlParser.java
@@ -15,15 +15,16 @@
  */
 package io.process.analytics.tools.bpmn.generator.internal;
 
-import io.process.analytics.tools.bpmn.generator.internal.model.ObjectFactory;
-import io.process.analytics.tools.bpmn.generator.internal.model.TDefinitions;
+import java.io.File;
+import java.io.StringReader;
 
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBElement;
 import javax.xml.bind.JAXBException;
 import javax.xml.transform.stream.StreamSource;
-import java.io.File;
-import java.io.StringReader;
+
+import io.process.analytics.tools.bpmn.generator.internal.generated.model.ObjectFactory;
+import io.process.analytics.tools.bpmn.generator.internal.generated.model.TDefinitions;
 
 public class XmlParser {
     private static final JAXBContext context = initContext();

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/XmlParser.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/XmlParser.java
@@ -21,6 +21,7 @@ import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBElement;
 import javax.xml.bind.JAXBException;
 import javax.xml.transform.stream.StreamSource;
+import java.io.File;
 import java.io.StringReader;
 
 public class XmlParser {
@@ -34,9 +35,9 @@ public class XmlParser {
         }
     }
 
-    public void marshal() {
+    public void marshal(TDefinitions definitions, File outputFile) {
         try {
-            context.createMarshaller().marshal(null, System.out);
+            context.createMarshaller().marshal(definitions, outputFile);
         } catch (JAXBException e) {
             throw new RuntimeException("Unable to marshal", e);
         }

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/XmlParser.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/XmlParser.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.process.analytics.tools.bpmn.generator.internal;
+
+import io.process.analytics.tools.bpmn.generator.internal.model.TDefinitions;
+
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import java.io.StringReader;
+
+public class XmlParser {
+    private static final JAXBContext context = initContext();
+
+    private static JAXBContext initContext() {
+        try {
+            return JAXBContext.newInstance(TDefinitions.class);
+        } catch (JAXBException e) {
+            throw new RuntimeException("Unable to initialize the JAXBContext", e);
+        }
+    }
+
+    public void marshal() {
+        try {
+            context.createMarshaller().marshal(null, System.out);
+        } catch (JAXBException e) {
+            throw new RuntimeException("Unable to marshal", e);
+        }
+    }
+
+    public TDefinitions unmarshall(String xml) {
+        try {
+            return (TDefinitions) context.createUnmarshaller().unmarshal(new StringReader(xml));
+        } catch (JAXBException e) {
+            throw new RuntimeException("Unable to marshal", e);
+        }
+    }
+
+}

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/XmlParser.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/XmlParser.java
@@ -15,6 +15,7 @@
  */
 package io.process.analytics.tools.bpmn.generator.internal;
 
+import io.process.analytics.tools.bpmn.generator.internal.model.ObjectFactory;
 import io.process.analytics.tools.bpmn.generator.internal.model.TDefinitions;
 
 import javax.xml.bind.JAXBContext;
@@ -37,7 +38,8 @@ public class XmlParser {
 
     public void marshal(TDefinitions definitions, File outputFile) {
         try {
-            context.createMarshaller().marshal(definitions, outputFile);
+            JAXBElement<TDefinitions> root = new ObjectFactory().createDefinitions(definitions);
+            context.createMarshaller().marshal(root, outputFile);
         } catch (JAXBException e) {
             throw new RuntimeException("Unable to marshal", e);
         }

--- a/java/src/main/xsd/BPMN20.xsd
+++ b/java/src/main/xsd/BPMN20.xsd
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema elementFormDefault="qualified" attributeFormDefault="unqualified"	
+	xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+	targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL">
+
+	<xsd:import namespace="http://www.omg.org/spec/BPMN/20100524/DI" schemaLocation="BPMNDI.xsd"/>
+	<xsd:include schemaLocation="Semantic.xsd"/>
+
+	<xsd:element name="definitions" type="tDefinitions"/>
+	<xsd:complexType name="tDefinitions">
+		<xsd:sequence>
+			<xsd:element ref="import" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="extension" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="rootElement" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="bpmndi:BPMNDiagram" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="relationship" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="xsd:ID" use="optional"/>
+		<xsd:attribute name="name" type="xsd:string"/>
+		<xsd:attribute name="targetNamespace" type="xsd:anyURI" use="required"/>
+		<xsd:attribute name="expressionLanguage" type="xsd:anyURI" use="optional" default="http://www.w3.org/1999/XPath"/>
+		<xsd:attribute name="typeLanguage" type="xsd:anyURI" use="optional" default="http://www.w3.org/2001/XMLSchema"/>
+		<xsd:attribute name="exporter" type="xsd:string"/>
+		<xsd:attribute name="exporterVersion" type="xsd:string"/>
+		<xsd:anyAttribute namespace="##other" processContents="lax"/>
+	</xsd:complexType>
+	
+	<xsd:element name="import" type="tImport"/>
+	<xsd:complexType name="tImport">
+		<xsd:attribute name="namespace" type="xsd:anyURI" use="required"/>
+		<xsd:attribute name="location" type="xsd:string" use="required"/>
+		<xsd:attribute name="importType" type="xsd:anyURI" use="required"/>
+	</xsd:complexType>
+
+</xsd:schema>

--- a/java/src/main/xsd/BPMNDI.xsd
+++ b/java/src/main/xsd/BPMNDI.xsd
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" targetNamespace="http://www.omg.org/spec/BPMN/20100524/DI"  elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.omg.org/spec/DD/20100524/DC" schemaLocation="DC.xsd" />
+	<xsd:import namespace="http://www.omg.org/spec/DD/20100524/DI" schemaLocation="DI.xsd" />
+	
+	<xsd:element name="BPMNDiagram" type="bpmndi:BPMNDiagram" />
+	<xsd:element name="BPMNPlane" type="bpmndi:BPMNPlane" />
+	<xsd:element name="BPMNLabelStyle" type="bpmndi:BPMNLabelStyle" />
+	<xsd:element name="BPMNShape" type="bpmndi:BPMNShape" substitutionGroup="di:DiagramElement" />
+	<xsd:element name="BPMNLabel" type="bpmndi:BPMNLabel" />
+	<xsd:element name="BPMNEdge" type="bpmndi:BPMNEdge" substitutionGroup="di:DiagramElement" />
+	
+	<xsd:complexType name="BPMNDiagram">
+		<xsd:complexContent>
+			<xsd:extension base="di:Diagram">
+				<xsd:sequence>
+					<xsd:element ref="bpmndi:BPMNPlane" />
+					<xsd:element ref="bpmndi:BPMNLabelStyle" maxOccurs="unbounded" minOccurs="0" />
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:complexType name="BPMNPlane">
+		<xsd:complexContent>
+			<xsd:extension base="di:Plane">
+				<xsd:attribute name="bpmnElement" type="xsd:QName" />
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:complexType name="BPMNEdge">
+		<xsd:complexContent>
+			<xsd:extension base="di:LabeledEdge">
+				<xsd:sequence>
+					<xsd:element ref="bpmndi:BPMNLabel" minOccurs="0" />
+				</xsd:sequence>
+				<xsd:attribute name="bpmnElement" type="xsd:QName" />
+				<xsd:attribute name="sourceElement" type="xsd:QName" />
+				<xsd:attribute name="targetElement" type="xsd:QName" />
+				<xsd:attribute name="messageVisibleKind" type="bpmndi:MessageVisibleKind" />
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:complexType name="BPMNShape">
+		<xsd:complexContent>
+			<xsd:extension base="di:LabeledShape">
+				<xsd:sequence>
+					<xsd:element ref="bpmndi:BPMNLabel" minOccurs="0" />
+				</xsd:sequence>
+				<xsd:attribute name="bpmnElement" type="xsd:QName" />
+				<xsd:attribute name="isHorizontal" type="xsd:boolean" />
+				<xsd:attribute name="isExpanded" type="xsd:boolean" />
+				<xsd:attribute name="isMarkerVisible" type="xsd:boolean" />
+				<xsd:attribute name="isMessageVisible" type="xsd:boolean" />
+				<xsd:attribute name="participantBandKind" type="bpmndi:ParticipantBandKind" />
+        		<xsd:attribute name="choreographyActivityShape" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:complexType name="BPMNLabel">
+		<xsd:complexContent>
+			<xsd:extension base="di:Label">
+				<xsd:attribute name="labelStyle" type="xsd:QName" />
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:complexType name="BPMNLabelStyle">
+		<xsd:complexContent>
+			<xsd:extension base="di:Style">
+				<xsd:sequence>
+					<xsd:element ref="dc:Font" />
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:simpleType name="ParticipantBandKind">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="top_initiating" />
+			<xsd:enumeration value="middle_initiating" />
+			<xsd:enumeration value="bottom_initiating" />
+			<xsd:enumeration value="top_non_initiating" />
+			<xsd:enumeration value="middle_non_initiating" />
+			<xsd:enumeration value="bottom_non_initiating" />
+		</xsd:restriction>
+	</xsd:simpleType>
+	
+	<xsd:simpleType name="MessageVisibleKind">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="initiating" />
+			<xsd:enumeration value="non_initiating" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+</xsd:schema>

--- a/java/src/main/xsd/DC.xsd
+++ b/java/src/main/xsd/DC.xsd
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" targetNamespace="http://www.omg.org/spec/DD/20100524/DC" elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:element name="Font" type="dc:Font" />
+	<xsd:element name="Point" type="dc:Point" />
+	<xsd:element name="Bounds" type="dc:Bounds" />
+	
+	<xsd:complexType name="Font">
+		<xsd:attribute name="name" type="xsd:string" />
+		<xsd:attribute name="size" type="xsd:double" />
+		<xsd:attribute name="isBold" type="xsd:boolean" />
+		<xsd:attribute name="isItalic" type="xsd:boolean" />
+		<xsd:attribute name="isUnderline" type="xsd:boolean" />
+		<xsd:attribute name="isStrikeThrough" type="xsd:boolean" />
+	</xsd:complexType>
+	
+	<xsd:complexType name="Point">
+		<xsd:attribute name="x" type="xsd:double" use="required" />
+		<xsd:attribute name="y" type="xsd:double" use="required" />
+	</xsd:complexType>
+	
+	<xsd:complexType name="Bounds">
+		<xsd:attribute name="x" type="xsd:double" use="required" />
+		<xsd:attribute name="y" type="xsd:double" use="required" />
+		<xsd:attribute name="width" type="xsd:double" use="required" />
+		<xsd:attribute name="height" type="xsd:double" use="required" />
+	</xsd:complexType>
+
+</xsd:schema>

--- a/java/src/main/xsd/DI.xsd
+++ b/java/src/main/xsd/DI.xsd
@@ -1,0 +1,100 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" targetNamespace="http://www.omg.org/spec/DD/20100524/DI" elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.omg.org/spec/DD/20100524/DC" schemaLocation="DC.xsd" />
+	
+	<xsd:element name="DiagramElement" type="di:DiagramElement" />
+	<xsd:element name="Diagram" type="di:Diagram" />
+	<xsd:element name="Style" type="di:Style" />
+	<xsd:element name="Node" type="di:Node" />
+	<xsd:element name="Edge" type="di:Edge" />
+	<xsd:element name="Shape" type="di:Shape" />
+	<xsd:element name="Plane" type="di:Plane" />
+	<xsd:element name="LabeledEdge" type="di:LabeledEdge" />
+	<xsd:element name="Label" type="di:Label" />
+	<xsd:element name="LabeledShape" type="di:LabeledShape" />
+	
+	<xsd:complexType abstract="true" name="DiagramElement">
+		<xsd:sequence>
+			<xsd:element name="extension" minOccurs="0">
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:any namespace="##other" minOccurs="0" maxOccurs="unbounded" />
+					</xsd:sequence>
+				</xsd:complexType>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="xsd:ID" />
+		<xsd:anyAttribute namespace="##other" processContents="lax" />
+	</xsd:complexType>
+	
+	<xsd:complexType abstract="true" name="Diagram">
+		<xsd:attribute name="name" type="xsd:string" />
+		<xsd:attribute name="documentation" type="xsd:string" />
+		<xsd:attribute name="resolution" type="xsd:double" />
+		<xsd:attribute name="id" type="xsd:ID" />
+	</xsd:complexType>
+	
+	<xsd:complexType abstract="true" name="Node">
+		<xsd:complexContent>
+			<xsd:extension base="di:DiagramElement" />
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:complexType abstract="true" name="Edge">
+		<xsd:complexContent>
+			<xsd:extension base="di:DiagramElement">
+				<xsd:sequence>
+					<xsd:element maxOccurs="unbounded" minOccurs="2" name="waypoint" type="dc:Point" />
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:complexType abstract="true" name="LabeledEdge">
+		<xsd:complexContent>
+			<xsd:extension base="di:Edge" />
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:complexType abstract="true" name="Shape">
+		<xsd:complexContent>
+			<xsd:extension base="di:Node">
+				<xsd:sequence>
+					<xsd:element ref="dc:Bounds" />
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:complexType abstract="true" name="LabeledShape">
+		<xsd:complexContent>
+			<xsd:extension base="di:Shape" />
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:complexType abstract="true" name="Label">
+		<xsd:complexContent>
+			<xsd:extension base="di:Node">
+				<xsd:sequence>
+					<xsd:element ref="dc:Bounds" minOccurs="0" />
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:complexType abstract="true" name="Plane">
+		<xsd:complexContent>
+			<xsd:extension base="di:Node">
+				<xsd:sequence>
+					<xsd:element ref="di:DiagramElement" maxOccurs="unbounded" minOccurs="0" />
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:complexType abstract="true" name="Style">
+		<xsd:attribute name="id" type="xsd:ID" />
+	</xsd:complexType>
+	
+</xsd:schema>

--- a/java/src/main/xsd/Semantic.xsd
+++ b/java/src/main/xsd/Semantic.xsd
@@ -1,0 +1,1562 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema elementFormDefault="qualified" attributeFormDefault="unqualified"
+	xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" 
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+	targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL">
+	
+	<xsd:element name="activity" type="tActivity"/>
+	<xsd:complexType name="tActivity" abstract="true">
+		<xsd:complexContent>
+			<xsd:extension base="tFlowNode">
+				<xsd:sequence>
+					<xsd:element ref="ioSpecification" minOccurs="0" maxOccurs="1"/>
+					<xsd:element ref="property" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="dataInputAssociation" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="dataOutputAssociation" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="resourceRole" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="loopCharacteristics" minOccurs="0"/>
+				</xsd:sequence>
+				<xsd:attribute name="isForCompensation" type="xsd:boolean" default="false"/>
+				<xsd:attribute name="startQuantity" type="xsd:integer" default="1"/>
+				<xsd:attribute name="completionQuantity" type="xsd:integer" default="1"/>
+				<xsd:attribute name="default" type="xsd:IDREF" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="adHocSubProcess" type="tAdHocSubProcess" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tAdHocSubProcess">
+		<xsd:complexContent>
+			<xsd:extension base="tSubProcess">
+				<xsd:sequence>
+					<xsd:element name="completionCondition" type="tExpression" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="cancelRemainingInstances" type="xsd:boolean" default="true"/>
+				<xsd:attribute name="ordering" type="tAdHocOrdering"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:simpleType name="tAdHocOrdering">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="Parallel"/>
+			<xsd:enumeration value="Sequential"/>
+		</xsd:restriction>
+	</xsd:simpleType>	
+
+	<xsd:element name="artifact" type="tArtifact"/>
+	<xsd:complexType name="tArtifact" abstract="true">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="assignment" type="tAssignment" />
+	<xsd:complexType name="tAssignment">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element name="from" type="tExpression" minOccurs="1" maxOccurs="1"/>
+					<xsd:element name="to" type="tExpression" minOccurs="1" maxOccurs="1"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>	
+	
+	<xsd:element name="association" type="tAssociation" substitutionGroup="artifact"/>
+	<xsd:complexType name="tAssociation">
+		<xsd:complexContent>
+			<xsd:extension base="tArtifact">
+				<xsd:attribute name="sourceRef" type="xsd:QName" use="required"/>
+				<xsd:attribute name="targetRef" type="xsd:QName" use="required"/>
+				<xsd:attribute name="associationDirection" type="tAssociationDirection" default="None"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:simpleType name="tAssociationDirection">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="None"/>
+			<xsd:enumeration value="One"/>
+			<xsd:enumeration value="Both"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:element name="auditing" type="tAuditing"/>
+	<xsd:complexType name="tAuditing">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement"/>
+		</xsd:complexContent>
+	</xsd:complexType>	
+
+	<xsd:element name="baseElement" type="tBaseElement"/>
+	<xsd:complexType name="tBaseElement" abstract="true">
+		<xsd:sequence>
+			<xsd:element ref="documentation" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="extensionElements" minOccurs="0" maxOccurs="1" /> 
+		</xsd:sequence>
+		<xsd:attribute name="id" type="xsd:ID" use="optional"/>
+		<xsd:anyAttribute namespace="##other" processContents="lax"/>
+	</xsd:complexType>
+	
+	<xsd:element name="baseElementWithMixedContent" type="tBaseElementWithMixedContent"/>
+	<xsd:complexType name="tBaseElementWithMixedContent" abstract="true" mixed="true">
+		<xsd:sequence>
+			<xsd:element ref="documentation" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="extensionElements" minOccurs="0" maxOccurs="1" /> 
+		</xsd:sequence>
+		<xsd:attribute name="id" type="xsd:ID" use="optional"/>
+		<xsd:anyAttribute namespace="##other" processContents="lax"/>
+	</xsd:complexType>
+
+	<xsd:element name="boundaryEvent" type="tBoundaryEvent" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tBoundaryEvent">
+		<xsd:complexContent>
+			<xsd:extension base="tCatchEvent">
+				<xsd:attribute name="cancelActivity" type="xsd:boolean" default="true"/>
+				<xsd:attribute name="attachedToRef" type="xsd:QName" use="required"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>			
+
+	<xsd:element name="businessRuleTask" type="tBusinessRuleTask" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tBusinessRuleTask">
+		<xsd:complexContent>
+			<xsd:extension base="tTask">
+				<xsd:attribute name="implementation" type="tImplementation" default="##unspecified"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="callableElement" type="tCallableElement"/>
+	<xsd:complexType name="tCallableElement">
+		<xsd:complexContent>
+			<xsd:extension base="tRootElement">
+				<xsd:sequence>
+					<xsd:element name="supportedInterfaceRef" type="xsd:QName" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="ioSpecification" minOccurs="0" maxOccurs="1"/>
+					<xsd:element ref="ioBinding" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="callActivity" type="tCallActivity" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tCallActivity">
+		<xsd:complexContent>
+			<xsd:extension base="tActivity">
+				<xsd:attribute name="calledElement" type="xsd:QName" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="callChoreography" type="tCallChoreography" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tCallChoreography">
+		<xsd:complexContent>
+			<xsd:extension base="tChoreographyActivity">
+				<xsd:sequence>
+					<xsd:element ref="participantAssociation" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="calledChoreographyRef" type="xsd:QName" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="callConversation" type="tCallConversation" substitutionGroup="conversationNode"/>
+	<xsd:complexType name="tCallConversation">
+		<xsd:complexContent>
+			<xsd:extension base="tConversationNode">
+				<xsd:sequence>
+					<xsd:element ref="participantAssociation" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="calledCollaborationRef" type="xsd:QName" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="cancelEventDefinition" type="tCancelEventDefinition" substitutionGroup="eventDefinition"/>
+	<xsd:complexType name="tCancelEventDefinition">
+		<xsd:complexContent>
+			<xsd:extension base="tEventDefinition"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="catchEvent" type="tCatchEvent"/>
+	<xsd:complexType name="tCatchEvent" abstract="true">
+		<xsd:complexContent>
+			<xsd:extension base="tEvent">
+				<xsd:sequence>
+					<xsd:element ref="dataOutput" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="dataOutputAssociation" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="outputSet" minOccurs="0" maxOccurs="1"/>
+					<xsd:element ref="eventDefinition" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="eventDefinitionRef" type="xsd:QName" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="parallelMultiple" type="xsd:boolean" default="false"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="category" type="tCategory" substitutionGroup="rootElement"/>
+	<xsd:complexType name="tCategory">
+		<xsd:complexContent>
+			<xsd:extension base="tRootElement">
+				<xsd:sequence>
+					<xsd:element ref="categoryValue" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="categoryValue" type="tCategoryValue"/>
+	<xsd:complexType name="tCategoryValue">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:attribute name="value" type="xsd:string" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="choreography" type="tChoreography" substitutionGroup="collaboration"/>
+	<xsd:complexType name="tChoreography">
+		<xsd:complexContent>
+			<xsd:extension base="tCollaboration">
+				<xsd:sequence>
+					<xsd:element ref="flowElement" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="choreographyActivity" type="tChoreographyActivity"/>
+	<xsd:complexType name="tChoreographyActivity" abstract="true">
+		<xsd:complexContent>
+			<xsd:extension base="tFlowNode">
+				<xsd:sequence>
+					<xsd:element name="participantRef" type="xsd:QName" minOccurs="2" maxOccurs="unbounded"/>
+					<xsd:element ref="correlationKey" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="initiatingParticipantRef" type="xsd:QName" use="required"/>
+				<xsd:attribute name="loopType" type="tChoreographyLoopType" default="None"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:simpleType name="tChoreographyLoopType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="None"/>
+			<xsd:enumeration value="Standard"/>
+			<xsd:enumeration value="MultiInstanceSequential"/>
+			<xsd:enumeration value="MultiInstanceParallel"/>
+		</xsd:restriction>
+	</xsd:simpleType>	
+	
+	<xsd:element name="choreographyTask" type="tChoreographyTask" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tChoreographyTask">
+		<xsd:complexContent>
+			<xsd:extension base="tChoreographyActivity">
+				<xsd:sequence>
+					<xsd:element name="messageFlowRef" type="xsd:QName" minOccurs="1" maxOccurs="2"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="collaboration" type="tCollaboration" substitutionGroup="rootElement"/>
+	<xsd:complexType name="tCollaboration">
+		<xsd:complexContent>
+			<xsd:extension base="tRootElement">
+				<xsd:sequence>
+					<xsd:element ref="participant" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="messageFlow" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="artifact" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="conversationNode" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="conversationAssociation" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="participantAssociation" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="messageFlowAssociation" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="correlationKey" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="choreographyRef" type="xsd:QName" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="conversationLink" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string"/>
+				<xsd:attribute name="isClosed" type="xsd:boolean" default="false"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="compensateEventDefinition" type="tCompensateEventDefinition" substitutionGroup="eventDefinition"/>
+	<xsd:complexType name="tCompensateEventDefinition">
+		<xsd:complexContent>
+			<xsd:extension base="tEventDefinition">
+				<xsd:attribute name="waitForCompletion" type="xsd:boolean"/>
+				<xsd:attribute name="activityRef" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="complexBehaviorDefinition" type="tComplexBehaviorDefinition"/>
+	<xsd:complexType name="tComplexBehaviorDefinition">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element name="condition" type="tFormalExpression" minOccurs="1" maxOccurs="1"/>
+					<xsd:element name="event" type="tImplicitThrowEvent" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="complexGateway" type="tComplexGateway" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tComplexGateway">
+		<xsd:complexContent>
+			<xsd:extension base="tGateway">
+				<xsd:sequence>
+					<xsd:element name="activationCondition" type="tExpression" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="default" type="xsd:IDREF"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>	
+	
+	<xsd:element name="conditionalEventDefinition" type="tConditionalEventDefinition" substitutionGroup="eventDefinition"/>
+	<xsd:complexType name="tConditionalEventDefinition">
+		<xsd:complexContent>
+			<xsd:extension base="tEventDefinition">
+				<xsd:sequence>
+					<xsd:element name="condition" type="tExpression"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="conversation" type="tConversation" substitutionGroup="conversationNode"/>
+	<xsd:complexType name="tConversation">
+		<xsd:complexContent>
+			<xsd:extension base="tConversationNode"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="conversationAssociation" type="tConversationAssociation"/>
+	<xsd:complexType name="tConversationAssociation">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:attribute name="innerConversationNodeRef" type="xsd:QName" use="required"/>
+				<xsd:attribute name="outerConversationNodeRef" type="xsd:QName" use="required"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="conversationLink" type="tConversationLink"/> 
+	<xsd:complexType name="tConversationLink"> 
+		<xsd:complexContent> 
+			<xsd:extension base="tBaseElement"> 
+				<xsd:attribute name="name" type="xsd:string" use="optional"/> 
+				<xsd:attribute name="sourceRef" type="xsd:QName" use="required"/> 
+				<xsd:attribute name="targetRef" type="xsd:QName" use="required"/> 
+			</xsd:extension> 
+		</xsd:complexContent> 
+	</xsd:complexType>
+  
+	<xsd:element name="conversationNode" type="tConversationNode"/>
+	<xsd:complexType name="tConversationNode" abstract="true">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element name="participantRef" type="xsd:QName" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="messageFlowRef" type="xsd:QName" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="correlationKey" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="correlationKey" type="tCorrelationKey"/>
+	<xsd:complexType name="tCorrelationKey">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element name="correlationPropertyRef" type="xsd:QName" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="correlationProperty" type="tCorrelationProperty" substitutionGroup="rootElement"/>
+	<xsd:complexType name="tCorrelationProperty">
+		<xsd:complexContent>
+			<xsd:extension base="tRootElement">
+				<xsd:sequence>
+					<xsd:element ref="correlationPropertyRetrievalExpression" minOccurs="1" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string" use="optional"/>
+				<xsd:attribute name="type" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="correlationPropertyBinding" type="tCorrelationPropertyBinding"/>
+	<xsd:complexType name="tCorrelationPropertyBinding">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element name="dataPath" type="tFormalExpression" minOccurs="1" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="correlationPropertyRef" type="xsd:QName" use="required"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="correlationPropertyRetrievalExpression" type="tCorrelationPropertyRetrievalExpression"/>
+	<xsd:complexType name="tCorrelationPropertyRetrievalExpression">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element name="messagePath" type="tFormalExpression" minOccurs="1" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="messageRef" type="xsd:QName" use="required"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="correlationSubscription" type="tCorrelationSubscription"/>
+	<xsd:complexType name="tCorrelationSubscription">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element ref="correlationPropertyBinding" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="correlationKeyRef" type="xsd:QName" use="required"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="dataAssociation" type="tDataAssociation" />
+	<xsd:complexType name="tDataAssociation">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element name="sourceRef" type="xsd:IDREF" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="targetRef" type="xsd:IDREF" minOccurs="1" maxOccurs="1"/>
+					<xsd:element name="transformation" type="tFormalExpression" minOccurs="0" maxOccurs="1"/>
+					<xsd:element ref="assignment" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>	
+	
+	<xsd:element name="dataInput" type="tDataInput" />
+	<xsd:complexType name="tDataInput">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element ref="dataState" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string" use="optional"/>
+				<xsd:attribute name="itemSubjectRef" type="xsd:QName" />
+				<xsd:attribute name="isCollection" type="xsd:boolean" default="false"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="dataInputAssociation" type="tDataInputAssociation" />
+	<xsd:complexType name="tDataInputAssociation">
+		<xsd:complexContent>
+			<xsd:extension base="tDataAssociation"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="dataObject" type="tDataObject" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tDataObject">
+		<xsd:complexContent>
+			<xsd:extension base="tFlowElement">
+				<xsd:sequence>
+					<xsd:element ref="dataState" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="itemSubjectRef" type="xsd:QName"/>
+				<xsd:attribute name="isCollection" type="xsd:boolean" default="false"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="dataObjectReference" type="tDataObjectReference" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tDataObjectReference">
+		<xsd:complexContent>
+			<xsd:extension base="tFlowElement">
+				<xsd:sequence>
+					<xsd:element ref="dataState" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="itemSubjectRef" type="xsd:QName"/>
+				<xsd:attribute name="dataObjectRef" type="xsd:IDREF"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="dataOutput" type="tDataOutput" />
+	<xsd:complexType name="tDataOutput">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element ref="dataState" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string" use="optional" />
+				<xsd:attribute name="itemSubjectRef" type="xsd:QName"/>
+				<xsd:attribute name="isCollection" type="xsd:boolean" default="false"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="dataOutputAssociation" type="tDataOutputAssociation" />
+	<xsd:complexType name="tDataOutputAssociation">
+		<xsd:complexContent>
+			<xsd:extension base="tDataAssociation"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="dataState" type="tDataState" />
+	<xsd:complexType name="tDataState">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:attribute name="name" type="xsd:string"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="dataStore" type="tDataStore" substitutionGroup="rootElement"/>
+	<xsd:complexType name="tDataStore">
+		<xsd:complexContent>
+			<xsd:extension base="tRootElement">
+				<xsd:sequence>
+					<xsd:element ref="dataState" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string"/>
+				<xsd:attribute name="capacity" type="xsd:integer"/>
+				<xsd:attribute name="isUnlimited" type="xsd:boolean" default="true"/>
+				<xsd:attribute name="itemSubjectRef" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="dataStoreReference" type="tDataStoreReference" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tDataStoreReference">
+		<xsd:complexContent>
+			<xsd:extension base="tFlowElement">
+				<xsd:sequence>
+					<xsd:element ref="dataState" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="itemSubjectRef" type="xsd:QName"/>
+				<xsd:attribute name="dataStoreRef" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="documentation" type="tDocumentation"/>
+	<xsd:complexType name="tDocumentation" mixed="true">
+		<xsd:sequence>
+			<xsd:any namespace="##any" processContents="lax" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="xsd:ID" use="optional"/>
+		<xsd:attribute name="textFormat" type="xsd:string" default="text/plain"/>
+	</xsd:complexType>
+	
+	<xsd:element name="endEvent" type="tEndEvent" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tEndEvent">
+		<xsd:complexContent>
+			<xsd:extension base="tThrowEvent"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="endPoint" type="tEndPoint" substitutionGroup="rootElement"/>
+	<xsd:complexType name="tEndPoint">
+		<xsd:complexContent>
+			<xsd:extension base="tRootElement"/>
+		</xsd:complexContent>
+	</xsd:complexType>		
+	
+	<xsd:element name="error" type="tError" substitutionGroup="rootElement"/>
+	<xsd:complexType name="tError">
+		<xsd:complexContent>
+			<xsd:extension base="tRootElement">
+				<xsd:attribute name="name" type="xsd:string"/>
+				<xsd:attribute name="errorCode" type="xsd:string"/>
+				<xsd:attribute name="structureRef" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="errorEventDefinition" type="tErrorEventDefinition" substitutionGroup="eventDefinition"/>
+	<xsd:complexType name="tErrorEventDefinition">
+		<xsd:complexContent>
+			<xsd:extension base="tEventDefinition">
+				<xsd:attribute name="errorRef" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="escalation" type="tEscalation" substitutionGroup="rootElement"/>	
+	<xsd:complexType name="tEscalation">
+		<xsd:complexContent>
+			<xsd:extension base="tRootElement">
+				<xsd:attribute name="name" type="xsd:string"/>
+				<xsd:attribute name="escalationCode" type="xsd:string"/>
+				<xsd:attribute name="structureRef" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>	
+
+	<xsd:element name="escalationEventDefinition" type="tEscalationEventDefinition" substitutionGroup="eventDefinition"/>
+	<xsd:complexType name="tEscalationEventDefinition">
+		<xsd:complexContent>
+			<xsd:extension base="tEventDefinition">
+				<xsd:attribute name="escalationRef" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="event" type="tEvent" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tEvent" abstract="true">
+		<xsd:complexContent>
+			<xsd:extension base="tFlowNode">
+				<xsd:sequence>
+					<xsd:element ref="property" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>	
+	
+	<xsd:element name="eventBasedGateway" type="tEventBasedGateway" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tEventBasedGateway">
+		<xsd:complexContent>
+			<xsd:extension base="tGateway">
+				<xsd:attribute name="instantiate" type="xsd:boolean" default="false"/>
+				<xsd:attribute name="eventGatewayType" type="tEventBasedGatewayType" default="Exclusive"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>	
+	
+	<xsd:simpleType name="tEventBasedGatewayType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="Exclusive"/>
+			<xsd:enumeration value="Parallel"/>
+		</xsd:restriction>
+	</xsd:simpleType>	
+
+	<xsd:element name="eventDefinition" type="tEventDefinition" substitutionGroup="rootElement"/>
+	<xsd:complexType name="tEventDefinition" abstract="true">
+		<xsd:complexContent>
+			<xsd:extension base="tRootElement"/>
+		</xsd:complexContent>
+	</xsd:complexType>			
+
+	<xsd:element name="exclusiveGateway" type="tExclusiveGateway" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tExclusiveGateway">
+		<xsd:complexContent>
+			<xsd:extension base="tGateway">
+				<xsd:attribute name="default" type="xsd:IDREF" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>	
+	
+	<xsd:element name="expression" type="tExpression"/>
+	<xsd:complexType name="tExpression">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElementWithMixedContent"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="extension" type="tExtension"/>
+	<xsd:complexType name="tExtension">
+		<xsd:sequence>
+			<xsd:element ref="documentation" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="definition" type="xsd:QName"/>
+		<xsd:attribute name="mustUnderstand" type="xsd:boolean" use="optional" default="false"/>
+	</xsd:complexType>
+	
+	<xsd:element name="extensionElements" type="tExtensionElements" /> 
+	<xsd:complexType name="tExtensionElements">
+		<xsd:sequence>
+			<xsd:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded" /> 
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:element name="flowElement" type="tFlowElement"/>
+	<xsd:complexType name="tFlowElement" abstract="true">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element ref="auditing" minOccurs="0" maxOccurs="1"/>
+					<xsd:element ref="monitoring" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="categoryValueRef" type="xsd:QName" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="flowNode" type="tFlowNode"/>
+	<xsd:complexType name="tFlowNode" abstract="true">
+		<xsd:complexContent>
+			<xsd:extension base="tFlowElement">
+				<xsd:sequence>
+					<xsd:element name="incoming" type="xsd:QName" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="outgoing" type="xsd:QName" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>	
+
+	<xsd:element name="formalExpression" type="tFormalExpression" substitutionGroup="expression"/>
+	<xsd:complexType name="tFormalExpression">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:attribute name="language" type="xsd:anyURI" use="optional"/>
+				<xsd:attribute name="evaluatesToTypeRef" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="gateway" type="tGateway" abstract="true"/>
+	<xsd:complexType name="tGateway">
+		<xsd:complexContent>
+			<xsd:extension base="tFlowNode">
+				<xsd:attribute name="gatewayDirection" type="tGatewayDirection" default="Unspecified"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>	
+	
+	<xsd:simpleType name="tGatewayDirection">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="Unspecified"/>
+			<xsd:enumeration value="Converging"/>
+			<xsd:enumeration value="Diverging"/>
+			<xsd:enumeration value="Mixed"/>
+		</xsd:restriction>
+	</xsd:simpleType>	
+	
+	<xsd:element name="globalBusinessRuleTask" type="tGlobalBusinessRuleTask" substitutionGroup="rootElement"/>
+	<xsd:complexType name="tGlobalBusinessRuleTask">
+		<xsd:complexContent>
+			<xsd:extension base="tGlobalTask">
+				<xsd:attribute name="implementation" type="tImplementation" default="##unspecified"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="globalChoreographyTask" type="tGlobalChoreographyTask" substitutionGroup="choreography"/>
+	<xsd:complexType name="tGlobalChoreographyTask">
+		<xsd:complexContent>
+			<xsd:extension base="tChoreography">
+				<xsd:attribute name="initiatingParticipantRef" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="globalConversation" type="tGlobalConversation" substitutionGroup="collaboration"/>
+	<xsd:complexType name="tGlobalConversation">
+		<xsd:complexContent>
+			<xsd:extension base="tCollaboration"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="globalManualTask" type="tGlobalManualTask" substitutionGroup="rootElement"/>
+	<xsd:complexType name="tGlobalManualTask">
+		<xsd:complexContent>
+			<xsd:extension base="tGlobalTask"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="globalScriptTask" type="tGlobalScriptTask"  substitutionGroup="rootElement"/>
+	<xsd:complexType name="tGlobalScriptTask">
+		<xsd:complexContent>
+			<xsd:extension base="tGlobalTask">
+				<xsd:sequence>
+					<xsd:element ref="script" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="scriptLanguage" type="xsd:anyURI"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="globalTask" type="tGlobalTask" substitutionGroup="rootElement"/>
+	<xsd:complexType name="tGlobalTask">
+		<xsd:complexContent>
+			<xsd:extension base="tCallableElement">
+				<xsd:sequence>
+					<xsd:element ref="resourceRole" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="globalUserTask" type="tGlobalUserTask" substitutionGroup="rootElement"/>
+	<xsd:complexType name="tGlobalUserTask">
+		<xsd:complexContent>
+			<xsd:extension base="tGlobalTask">
+				<xsd:sequence>
+					<xsd:element ref="rendering" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="implementation" type="tImplementation" default="##unspecified"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="group" type="tGroup" substitutionGroup="artifact"/>
+	<xsd:complexType name="tGroup">
+		<xsd:complexContent>
+			<xsd:extension base="tArtifact">
+				<xsd:attribute name="categoryValueRef" type="xsd:QName" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="humanPerformer" type="tHumanPerformer" substitutionGroup="performer"/>
+	<xsd:complexType name="tHumanPerformer">
+		<xsd:complexContent>
+			<xsd:extension base="tPerformer"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:simpleType name="tImplementation">
+		<xsd:union memberTypes="xsd:anyURI">
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:token">
+					<xsd:enumeration value="##unspecified" /> 
+					<xsd:enumeration value="##WebService" />
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:union>
+	</xsd:simpleType>
+
+	<xsd:element name="implicitThrowEvent" type="tImplicitThrowEvent" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tImplicitThrowEvent">
+		<xsd:complexContent>
+			<xsd:extension base="tThrowEvent"/>
+		</xsd:complexContent>
+	</xsd:complexType>				
+	
+	<xsd:element name="inclusiveGateway" type="tInclusiveGateway" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tInclusiveGateway">
+		<xsd:complexContent>
+			<xsd:extension base="tGateway">
+				<xsd:attribute name="default" type="xsd:IDREF" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>	
+	
+	<xsd:element name="inputSet" type="tInputSet" />
+	<xsd:complexType name="tInputSet">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element name="dataInputRefs" type="xsd:IDREF" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="optionalInputRefs" type="xsd:IDREF" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="whileExecutingInputRefs" type="xsd:IDREF" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="outputSetRefs" type="xsd:IDREF" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string" />
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="interface" type="tInterface" substitutionGroup="rootElement"/>
+	<xsd:complexType name="tInterface">
+		<xsd:complexContent>
+			<xsd:extension base="tRootElement">
+				<xsd:sequence>
+					<xsd:element ref="operation" minOccurs="1" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string" use="required"/>
+				<xsd:attribute name="implementationRef" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="intermediateCatchEvent" type="tIntermediateCatchEvent" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tIntermediateCatchEvent">
+		<xsd:complexContent>
+			<xsd:extension base="tCatchEvent"/>
+		</xsd:complexContent>
+	</xsd:complexType>			
+
+	<xsd:element name="intermediateThrowEvent" type="tIntermediateThrowEvent" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tIntermediateThrowEvent">
+		<xsd:complexContent>
+			<xsd:extension base="tThrowEvent"/>
+		</xsd:complexContent>
+	</xsd:complexType>				
+
+	<xsd:element name="ioBinding" type="tInputOutputBinding" />
+	<xsd:complexType name="tInputOutputBinding">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:attribute name="operationRef" type="xsd:QName" use="required"/>
+				<xsd:attribute name="inputDataRef" type="xsd:IDREF" use="required"/>
+				<xsd:attribute name="outputDataRef" type="xsd:IDREF" use="required"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="ioSpecification" type="tInputOutputSpecification" />
+	<xsd:complexType name="tInputOutputSpecification">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element ref="dataInput" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="dataOutput" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="inputSet" minOccurs="1" maxOccurs="unbounded"/>
+					<xsd:element ref="outputSet" minOccurs="1" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="itemDefinition" type="tItemDefinition" substitutionGroup="rootElement"/>	
+	<xsd:complexType name="tItemDefinition">
+		<xsd:complexContent>
+			<xsd:extension base="tRootElement">
+				<xsd:attribute name="structureRef" type="xsd:QName"/>
+				<xsd:attribute name="isCollection" type="xsd:boolean" default="false"/>
+				<xsd:attribute name="itemKind" type="tItemKind" default="Information"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>		
+	
+	<xsd:simpleType name="tItemKind">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="Information"/>
+			<xsd:enumeration value="Physical"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:element name="lane" type="tLane"/>
+	<xsd:complexType name="tLane">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element name="partitionElement" type="tBaseElement" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="flowNodeRef" type="xsd:IDREF" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="childLaneSet" type="tLaneSet" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string"/>
+				<xsd:attribute name="partitionElementRef" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="laneSet" type="tLaneSet"/>
+	<xsd:complexType name="tLaneSet">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element ref="lane" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="linkEventDefinition" type="tLinkEventDefinition" substitutionGroup="eventDefinition"/>
+	<xsd:complexType name="tLinkEventDefinition">
+		<xsd:complexContent>
+			<xsd:extension base="tEventDefinition">
+				<xsd:sequence>
+					<xsd:element name="source" type="xsd:QName" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="target" type="xsd:QName" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string" use="required"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="loopCharacteristics" type="tLoopCharacteristics"/>
+	<xsd:complexType name="tLoopCharacteristics" abstract="true">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement"/>
+		</xsd:complexContent>
+	</xsd:complexType>	
+
+	<xsd:element name="manualTask" type="tManualTask" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tManualTask">
+		<xsd:complexContent>
+			<xsd:extension base="tTask"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="message" type="tMessage" substitutionGroup="rootElement"/>	
+	<xsd:complexType name="tMessage">
+		<xsd:complexContent>
+			<xsd:extension base="tRootElement">
+				<xsd:attribute name="name" type="xsd:string"/>
+				<xsd:attribute name="itemRef" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>		
+	
+	<xsd:element name="messageEventDefinition" type="tMessageEventDefinition" substitutionGroup="eventDefinition"/>
+	<xsd:complexType name="tMessageEventDefinition">
+		<xsd:complexContent>
+			<xsd:extension base="tEventDefinition">
+				<xsd:sequence>
+					<xsd:element name="operationRef" type="xsd:QName" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="messageRef" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="messageFlow" type="tMessageFlow"/>
+	<xsd:complexType name="tMessageFlow">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:attribute name="name" type="xsd:string" use="optional"/>
+				<xsd:attribute name="sourceRef" type="xsd:QName" use="required"/>
+				<xsd:attribute name="targetRef" type="xsd:QName" use="required"/>
+				<xsd:attribute name="messageRef" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="messageFlowAssociation" type="tMessageFlowAssociation"/>
+	<xsd:complexType name="tMessageFlowAssociation">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:attribute name="innerMessageFlowRef" type="xsd:QName" use="required"/>
+				<xsd:attribute name="outerMessageFlowRef" type="xsd:QName" use="required"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="monitoring" type="tMonitoring"/>
+	<xsd:complexType name="tMonitoring">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement"/>
+		</xsd:complexContent>
+	</xsd:complexType>	
+
+	<xsd:element name="multiInstanceLoopCharacteristics" type="tMultiInstanceLoopCharacteristics"  substitutionGroup="loopCharacteristics"/>
+	<xsd:complexType name="tMultiInstanceLoopCharacteristics">
+		<xsd:complexContent>
+			<xsd:extension base="tLoopCharacteristics">
+				<xsd:sequence>
+					<xsd:element name="loopCardinality" type="tExpression" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="loopDataInputRef" type="xsd:QName" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="loopDataOutputRef" type="xsd:QName" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="inputDataItem" type="tDataInput" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="outputDataItem" type="tDataOutput" minOccurs="0" maxOccurs="1"/>
+					<xsd:element ref="complexBehaviorDefinition" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="completionCondition" type="tExpression" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="isSequential" type="xsd:boolean" default="false"/>
+				<xsd:attribute name="behavior" type="tMultiInstanceFlowCondition" default="All"/>
+				<xsd:attribute name="oneBehaviorEventRef" type="xsd:QName" use="optional"/>
+				<xsd:attribute name="noneBehaviorEventRef" type="xsd:QName" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>	
+	
+	<xsd:simpleType name="tMultiInstanceFlowCondition">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="None"/>
+			<xsd:enumeration value="One"/>
+			<xsd:enumeration value="All"/>
+			<xsd:enumeration value="Complex"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	
+	<xsd:element name="operation" type="tOperation"/>
+	<xsd:complexType name="tOperation">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element name="inMessageRef" type="xsd:QName" minOccurs="1" maxOccurs="1"/>
+					<xsd:element name="outMessageRef" type="xsd:QName" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="errorRef" type="xsd:QName" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string" use="required"/>
+				<xsd:attribute name="implementationRef" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="outputSet" type="tOutputSet" />
+	<xsd:complexType name="tOutputSet">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element name="dataOutputRefs" type="xsd:IDREF" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="optionalOutputRefs" type="xsd:IDREF" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="whileExecutingOutputRefs" type="xsd:IDREF" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="inputSetRefs" type="xsd:IDREF" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="parallelGateway" type="tParallelGateway" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tParallelGateway">
+		<xsd:complexContent>
+			<xsd:extension base="tGateway"/>
+		</xsd:complexContent>
+	</xsd:complexType>	
+
+	<xsd:element name="participant" type="tParticipant"/>
+	<xsd:complexType name="tParticipant">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element name="interfaceRef" type="xsd:QName" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="endPointRef" type="xsd:QName" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="participantMultiplicity" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string"/>
+				<xsd:attribute name="processRef" type="xsd:QName" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="participantAssociation" type="tParticipantAssociation"/>
+	<xsd:complexType name="tParticipantAssociation">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element name="innerParticipantRef" type="xsd:QName" minOccurs="1" maxOccurs="1"/>
+					<xsd:element name="outerParticipantRef" type="xsd:QName" minOccurs="1" maxOccurs="1"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="participantMultiplicity" type="tParticipantMultiplicity"/>
+	<xsd:complexType name="tParticipantMultiplicity">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:attribute name="minimum" type="xsd:int" default="0"/>
+				<xsd:attribute name="maximum" type="xsd:int" default="1"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="partnerEntity" type="tPartnerEntity" substitutionGroup="rootElement"/>
+	<xsd:complexType name="tPartnerEntity">
+		<xsd:complexContent>
+			<xsd:extension base="tRootElement">
+				<xsd:sequence>
+					<xsd:element name="participantRef" type="xsd:QName" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="partnerRole" type="tPartnerRole" substitutionGroup="rootElement"/>
+	<xsd:complexType name="tPartnerRole">
+		<xsd:complexContent>
+			<xsd:extension base="tRootElement">
+				<xsd:sequence>
+					<xsd:element name="participantRef" type="xsd:QName" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="performer" type="tPerformer" substitutionGroup="resourceRole"/>
+	<xsd:complexType name="tPerformer">
+		<xsd:complexContent>
+			<xsd:extension base="tResourceRole"/>
+		</xsd:complexContent>
+	</xsd:complexType>	
+	
+	<xsd:element name="potentialOwner" type="tPotentialOwner" substitutionGroup="performer"/>
+	<xsd:complexType name="tPotentialOwner">
+		<xsd:complexContent>
+			<xsd:extension base="tHumanPerformer"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="process" type="tProcess" substitutionGroup="rootElement"/>
+	<xsd:complexType name="tProcess">
+		<xsd:complexContent>
+			<xsd:extension base="tCallableElement">
+				<xsd:sequence>
+					<xsd:element ref="auditing" minOccurs="0" maxOccurs="1"/>
+					<xsd:element ref="monitoring" minOccurs="0" maxOccurs="1"/>
+					<xsd:element ref="property" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="laneSet" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="flowElement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="artifact" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="resourceRole" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="correlationSubscription" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="supports" type="xsd:QName" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="processType" type="tProcessType" default="None"/>
+				<xsd:attribute name="isClosed" type="xsd:boolean" default="false"/>
+				<xsd:attribute name="isExecutable" type="xsd:boolean"/>
+				<xsd:attribute name="definitionalCollaborationRef" type="xsd:QName" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:simpleType name="tProcessType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="None"/>
+			<xsd:enumeration value="Public"/>
+			<xsd:enumeration value="Private"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:element name="property" type="tProperty" />
+	<xsd:complexType name="tProperty">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element ref="dataState" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string"/>
+				<xsd:attribute name="itemSubjectRef" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="receiveTask" type="tReceiveTask" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tReceiveTask">
+		<xsd:complexContent>
+			<xsd:extension base="tTask">
+				<xsd:attribute name="implementation" type="tImplementation" default="##WebService"/>
+				<xsd:attribute name="instantiate" type="xsd:boolean" default="false"/>
+				<xsd:attribute name="messageRef" type="xsd:QName" use="optional"/>
+				<xsd:attribute name="operationRef" type="xsd:QName" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>	
+	
+	<xsd:element name="relationship" type="tRelationship"/>
+	<xsd:complexType name="tRelationship">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element name="source" type="xsd:QName" minOccurs="1" maxOccurs="unbounded"/>
+					<xsd:element name="target" type="xsd:QName" minOccurs="1" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="type" type="xsd:string" use="required"/>
+				<xsd:attribute name="direction" type="tRelationshipDirection"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>	
+
+	<xsd:simpleType name="tRelationshipDirection">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="None"/>
+			<xsd:enumeration value="Forward"/>
+			<xsd:enumeration value="Backward"/>
+			<xsd:enumeration value="Both"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	
+	<xsd:element name="rendering" type="tRendering"/>
+	<xsd:complexType name="tRendering">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="resource" type="tResource" substitutionGroup="rootElement"/>
+	<xsd:complexType name="tResource">
+		<xsd:complexContent>
+			<xsd:extension base="tRootElement">
+				<xsd:sequence>
+					<xsd:element ref="resourceParameter" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string" use="required"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="resourceAssignmentExpression" type="tResourceAssignmentExpression"/>
+	<xsd:complexType name="tResourceAssignmentExpression">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element ref="expression" minOccurs="1" maxOccurs="1"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>	
+
+	<xsd:element name="resourceParameter" type="tResourceParameter"/>
+	<xsd:complexType name="tResourceParameter">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:attribute name="name" type="xsd:string"/>
+				<xsd:attribute name="type" type="xsd:QName"/>
+				<xsd:attribute name="isRequired" type="xsd:boolean"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="resourceParameterBinding" type="tResourceParameterBinding"/>
+	<xsd:complexType name="tResourceParameterBinding">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element ref="expression" minOccurs="1" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="parameterRef" type="xsd:QName" use="required"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>	
+
+	<xsd:element name="resourceRole" type="tResourceRole"/>
+	<xsd:complexType name="tResourceRole"> 
+		<xsd:complexContent> 
+			<xsd:extension base="tBaseElement"> 
+				<xsd:choice> 
+					<xsd:sequence> 
+						<xsd:element name="resourceRef" type="xsd:QName"/> 
+						<xsd:element ref="resourceParameterBinding" minOccurs="0" maxOccurs="unbounded"/> 
+					</xsd:sequence> 
+					<xsd:element ref="resourceAssignmentExpression" minOccurs="0" maxOccurs="1"/> 
+				</xsd:choice>
+				<xsd:attribute name="name" type="xsd:string"/>
+			</xsd:extension> 
+		</xsd:complexContent> 
+	</xsd:complexType>
+
+	<xsd:element name="rootElement" type="tRootElement"/>
+	<xsd:complexType name="tRootElement" abstract="true">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="scriptTask" type="tScriptTask" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tScriptTask">
+		<xsd:complexContent>
+			<xsd:extension base="tTask">
+				<xsd:sequence>
+					<xsd:element ref="script" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="scriptFormat" type="xsd:string"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>		
+	
+	<xsd:element name="script" type="tScript"/>
+	<xsd:complexType name="tScript" mixed="true">
+		<xsd:sequence>
+			<xsd:any namespace="##any" processContents="lax" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:complexType>	
+
+	<xsd:element name="sendTask" type="tSendTask" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tSendTask">
+		<xsd:complexContent>
+			<xsd:extension base="tTask">
+				<xsd:attribute name="implementation" type="tImplementation" default="##WebService"/>
+				<xsd:attribute name="messageRef" type="xsd:QName" use="optional"/>
+				<xsd:attribute name="operationRef" type="xsd:QName" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>	
+
+	<xsd:element name="sequenceFlow" type="tSequenceFlow" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tSequenceFlow">
+		<xsd:complexContent>
+			<xsd:extension base="tFlowElement">
+				<xsd:sequence>
+					<xsd:element name="conditionExpression"  type="tExpression" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="sourceRef" type="xsd:IDREF" use="required"/>
+				<xsd:attribute name="targetRef" type="xsd:IDREF" use="required"/>
+				<xsd:attribute name="isImmediate" type="xsd:boolean" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="serviceTask" type="tServiceTask" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tServiceTask">
+		<xsd:complexContent>
+			<xsd:extension base="tTask">
+				<xsd:attribute name="implementation" type="tImplementation" default="##WebService"/>
+				<xsd:attribute name="operationRef" type="xsd:QName" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>	
+	
+	<xsd:element name="signal" type="tSignal" substitutionGroup="rootElement"/>	
+	<xsd:complexType name="tSignal">
+		<xsd:complexContent>
+			<xsd:extension base="tRootElement">
+				<xsd:attribute name="name" type="xsd:string"/>
+				<xsd:attribute name="structureRef" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>	
+
+	<xsd:element name="signalEventDefinition" type="tSignalEventDefinition" substitutionGroup="eventDefinition"/>
+	<xsd:complexType name="tSignalEventDefinition">
+		<xsd:complexContent>
+			<xsd:extension base="tEventDefinition">
+				<xsd:attribute name="signalRef" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="standardLoopCharacteristics" type="tStandardLoopCharacteristics"  substitutionGroup="loopCharacteristics"/>
+	<xsd:complexType name="tStandardLoopCharacteristics">
+		<xsd:complexContent>
+			<xsd:extension base="tLoopCharacteristics">
+				<xsd:sequence>
+					<xsd:element name="loopCondition" type="tExpression" minOccurs="0"/>
+				</xsd:sequence>
+				<xsd:attribute name="testBefore" type="xsd:boolean" default="false"/>
+				<xsd:attribute name="loopMaximum" type="xsd:integer" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>	
+
+	<xsd:element name="startEvent" type="tStartEvent" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tStartEvent">
+		<xsd:complexContent>
+			<xsd:extension base="tCatchEvent">
+				<xsd:attribute name="isInterrupting" type="xsd:boolean" default="true"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>			
+	
+	<xsd:element name="subChoreography" type="tSubChoreography" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tSubChoreography">
+		<xsd:complexContent>
+			<xsd:extension base="tChoreographyActivity">
+				<xsd:sequence>
+					<xsd:element ref="flowElement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="artifact" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="subConversation" type="tSubConversation" substitutionGroup="conversationNode"/>
+	<xsd:complexType name="tSubConversation">
+		<xsd:complexContent>
+			<xsd:extension base="tConversationNode">
+				<xsd:sequence>
+					<xsd:element ref="conversationNode" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="subProcess" type="tSubProcess" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tSubProcess">
+		<xsd:complexContent>
+			<xsd:extension base="tActivity">
+				<xsd:sequence>
+					<xsd:element ref="laneSet" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="flowElement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="artifact" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="triggeredByEvent" type="xsd:boolean" default="false"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="task" type="tTask" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tTask">
+		<xsd:complexContent>
+			<xsd:extension base="tActivity"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="terminateEventDefinition" type="tTerminateEventDefinition" substitutionGroup="eventDefinition"/>
+	<xsd:complexType name="tTerminateEventDefinition">
+		<xsd:complexContent>
+			<xsd:extension base="tEventDefinition"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="textAnnotation" type="tTextAnnotation" substitutionGroup="artifact"/>
+	<xsd:complexType name="tTextAnnotation">
+		<xsd:complexContent>
+			<xsd:extension base="tArtifact">
+				<xsd:sequence>
+					<xsd:element ref="text" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="textFormat" type="xsd:string" default="text/plain"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="text" type="tText"/>
+	<xsd:complexType name="tText" mixed="true">
+		<xsd:sequence>
+			<xsd:any namespace="##any" processContents="lax" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:element name="throwEvent" type="tThrowEvent"/>
+	<xsd:complexType name="tThrowEvent" abstract="true">
+		<xsd:complexContent>
+			<xsd:extension base="tEvent">
+				<xsd:sequence>
+					<xsd:element ref="dataInput" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="dataInputAssociation" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="inputSet" minOccurs="0" maxOccurs="1"/>
+					<xsd:element ref="eventDefinition" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="eventDefinitionRef" type="xsd:QName" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>			
+	
+	<xsd:element name="timerEventDefinition" type="tTimerEventDefinition" substitutionGroup="eventDefinition"/>
+	<xsd:complexType name="tTimerEventDefinition">
+		<xsd:complexContent>
+			<xsd:extension base="tEventDefinition">
+				<xsd:choice>
+					<xsd:element name="timeDate" type="tExpression" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="timeDuration" type="tExpression" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="timeCycle" type="tExpression" minOccurs="0" maxOccurs="1"/>
+				</xsd:choice>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="transaction" type="tTransaction" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tTransaction">
+		<xsd:complexContent>
+			<xsd:extension base="tSubProcess">
+				<xsd:attribute name="method" type="tTransactionMethod" default="##Compensate"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:simpleType name="tTransactionMethod">
+		<xsd:union memberTypes="xsd:anyURI">
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:token">
+					<xsd:enumeration value="##Compensate" /> 
+					<xsd:enumeration value="##Image" />
+					<xsd:enumeration value="##Store" />
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:union>
+	</xsd:simpleType>
+
+	<xsd:element name="userTask" type="tUserTask" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tUserTask">
+		<xsd:complexContent>
+			<xsd:extension base="tTask">
+				<xsd:sequence>
+					<xsd:element ref="rendering" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="implementation" type="tImplementation" default="##unspecified"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+</xsd:schema>

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/AppTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/AppTest.java
@@ -25,10 +25,11 @@ public class AppTest {
 
     @Test
     public void main_generates_xml_output_file() {
-        String output = "target/test/output/A.2.0_with_diagram.bpmn.xml";
+        String output = "target/test/output/AppTest/A.2.0_with_diagram.bpmn.xml";
         generate("src/test/resources/bpmn/A.2.0.bpmn.xml", output);
 
         assertThat(new File(output)).exists();
+        // TODO add xml assertions (assertj and/or xmlunit)
     }
 
     // =================================================================================================================

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/AppTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/AppTest.java
@@ -15,14 +15,21 @@
  */
 package io.process.analytics.tools.bpmn.generator;
 
-import static org.junit.Assert.assertTrue;
-
+import io.process.analytics.tools.bpmn.generator.internal.model.BPMNDiagram;
+import io.process.analytics.tools.bpmn.generator.internal.model.BPMNPlane;
 import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 public class AppTest {
     @Test
-    public void shouldAnswerWithTrue() {
+    public void bpmn_diagram_can_be_instantiated() {
+        BPMNDiagram diagram = new BPMNDiagram();
+        BPMNPlane plane = new BPMNPlane();
+        diagram.setBPMNPlane(plane);
+        plane.setId("12");
 
-        assertTrue(true);
+        assertThat(plane.getId()).isEqualTo("12");
     }
+
 }

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/AppTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/AppTest.java
@@ -15,21 +15,28 @@
  */
 package io.process.analytics.tools.bpmn.generator;
 
-import io.process.analytics.tools.bpmn.generator.internal.model.BPMNDiagram;
-import io.process.analytics.tools.bpmn.generator.internal.model.BPMNPlane;
 import org.junit.jupiter.api.Test;
+
+import java.io.File;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class AppTest {
-    @Test
-    public void bpmn_diagram_can_be_instantiated() {
-        BPMNDiagram diagram = new BPMNDiagram();
-        BPMNPlane plane = new BPMNPlane();
-        diagram.setBPMNPlane(plane);
-        plane.setId("12");
 
-        assertThat(plane.getId()).isEqualTo("12");
+    @Test
+    public void main_generates_xml_output_file() {
+        String output = "target/test/output/A.2.0_with_diagram.bpmn.xml";
+        generate("src/test/resources/bpmn/A.2.0.bpmn.xml", output);
+
+        assertThat(new File(output)).exists();
+    }
+
+    // =================================================================================================================
+    // UTILS
+    // =================================================================================================================
+
+    private static void generate(String input, String output) {
+        App.main(new String[] { input, output });
     }
 
 }

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/AppTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/AppTest.java
@@ -17,7 +17,7 @@ package io.process.analytics.tools.bpmn.generator;
 
 import io.process.analytics.tools.bpmn.generator.internal.model.BPMNDiagram;
 import io.process.analytics.tools.bpmn.generator.internal.model.BPMNPlane;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/internal/BPMNDiagramRichBuilderTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/internal/BPMNDiagramRichBuilderTest.java
@@ -34,22 +34,20 @@ class BPMNDiagramRichBuilderTest {
     public void initializeBPMNDiagram_when_collaboration_exist_in_bpmn_file() {
         BPMNDiagramRichBuilder builder = newBuildFromBpmnFile("src/test/resources/bpmn/01-startEvent.bpmn.xml");
 
-        BPMNDiagram bpmnDiagram = builder.initializeBPMNDiagram();
-        BPMNPlane bpmnPlane = check(bpmnDiagram);
+        BPMNDiagram diagram = builder.initializeBPMNDiagram();
 
-        Map<QName, String> attributes = bpmnPlane.getOtherAttributes();
-        assertThat(attributes).containsValues("Collaboration_1cajy2f");
+        BPMNPlane plane = check(diagram);
+        checkBpmnElement(plane, "Collaboration_1cajy2f");
     }
 
     @Test
     public void initializeBPMNDiagram_when_collaboration_not_exist_in_bpmn_file() {
         BPMNDiagramRichBuilder builder = newBuildFromBpmnFile("src/test/resources/bpmn/02-startEvent_task_endEvent-without-collaboration.bpmn.xml");
 
-        BPMNDiagram bpmnDiagram = builder.initializeBPMNDiagram();
-        BPMNPlane bpmnPlane = check(bpmnDiagram);
+        BPMNDiagram diagram = builder.initializeBPMNDiagram();
 
-        Map<QName, String> attributes = bpmnPlane.getOtherAttributes();
-        assertThat(attributes).containsValues("process_1");
+        BPMNPlane plane = check(diagram);
+        checkBpmnElement(plane, "process_1");
     }
 
     @Test
@@ -78,6 +76,13 @@ class BPMNDiagramRichBuilderTest {
         BPMNPlane bpmnPlane = bpmnDiagram.getBPMNPlane();
         assertThat(bpmnPlane.getId()).isEqualTo("BPMNPlane_1");
         return bpmnPlane;
+    }
+
+    private static void checkBpmnElement(BPMNPlane plane, String expectedId) {
+        QName bpmnElement = plane.getBpmnElement();
+        assertThat(bpmnElement.getLocalPart()).isEqualTo(expectedId);
+        assertThat(bpmnElement.getNamespaceURI()).isEmpty();
+        assertThat(bpmnElement.getPrefix()).isEmpty();
     }
 
     private static BPMNDiagramRichBuilder newBuildFromBpmnFile(String bpmnFilePath) {

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/internal/BPMNDiagramRichBuilderTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/internal/BPMNDiagramRichBuilderTest.java
@@ -15,18 +15,19 @@
  */
 package io.process.analytics.tools.bpmn.generator.internal;
 
-import io.process.analytics.tools.bpmn.generator.internal.model.BPMNDiagram;
-import io.process.analytics.tools.bpmn.generator.internal.model.BPMNPlane;
-import io.process.analytics.tools.bpmn.generator.internal.model.TDefinitions;
-import org.junit.jupiter.api.Test;
-
-import javax.xml.namespace.QName;
-import java.io.File;
-import java.util.List;
-import java.util.Map;
-
 import static io.process.analytics.tools.bpmn.generator.internal.BpmnInOut.defaultBpmnInOut;
 import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.util.List;
+
+import javax.xml.namespace.QName;
+
+import org.junit.jupiter.api.Test;
+
+import io.process.analytics.tools.bpmn.generator.internal.generated.model.BPMNDiagram;
+import io.process.analytics.tools.bpmn.generator.internal.generated.model.BPMNPlane;
+import io.process.analytics.tools.bpmn.generator.internal.generated.model.TDefinitions;
 
 class BPMNDiagramRichBuilderTest {
 

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/internal/BPMNDiagramRichBuilderTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/internal/BPMNDiagramRichBuilderTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 
 import javax.xml.namespace.QName;
 import java.io.File;
+import java.util.List;
 import java.util.Map;
 
 import static io.process.analytics.tools.bpmn.generator.internal.BpmnInOut.defaultBpmnInOut;
@@ -36,6 +37,26 @@ class BPMNDiagramRichBuilderTest {
         Map<QName, String> attributes = bpmnPlane.getOtherAttributes();
         assertThat(attributes).containsValues("process_1");
     }
+
+    @Test
+    public void build_should_initialize_BPMNDiagram() {
+        BPMNDiagramRichBuilder builder = newBuildFromBpmnFile("src/test/resources/bpmn/A.2.0.bpmn.xml");
+
+        TDefinitions definitions = builder.build();
+
+        // TODO duplication with XmlParserTest + check method for id
+        // Shapes
+        List<BPMNDiagram> diagram = definitions.getBPMNDiagram();
+        assertThat(diagram)
+                .hasSize(1)
+                .extracting(BPMNDiagram::getId).containsOnly("BPMNDiagram_1");
+        BPMNPlane plane = diagram.get(0).getBPMNPlane();
+        assertThat(plane.getId()).isEqualTo("BPMNPlane_1");
+    }
+
+    // =================================================================================================================
+    // UTILS
+    // =================================================================================================================
 
     // always set like this
     private static BPMNPlane check(BPMNDiagram bpmnDiagram) {

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/internal/BPMNDiagramRichBuilderTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/internal/BPMNDiagramRichBuilderTest.java
@@ -1,9 +1,23 @@
+/*
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.process.analytics.tools.bpmn.generator.internal;
 
 import io.process.analytics.tools.bpmn.generator.internal.model.BPMNDiagram;
 import io.process.analytics.tools.bpmn.generator.internal.model.BPMNPlane;
 import io.process.analytics.tools.bpmn.generator.internal.model.TDefinitions;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import javax.xml.namespace.QName;

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/internal/BPMNDiagramRichBuilderTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/internal/BPMNDiagramRichBuilderTest.java
@@ -1,0 +1,56 @@
+package io.process.analytics.tools.bpmn.generator.internal;
+
+import io.process.analytics.tools.bpmn.generator.internal.model.BPMNDiagram;
+import io.process.analytics.tools.bpmn.generator.internal.model.BPMNPlane;
+import io.process.analytics.tools.bpmn.generator.internal.model.TDefinitions;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import javax.xml.namespace.QName;
+import java.io.File;
+import java.util.Map;
+
+import static io.process.analytics.tools.bpmn.generator.internal.BpmnInOut.defaultBpmnInOut;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BPMNDiagramRichBuilderTest {
+
+    @Test
+    public void initializeBPMNDiagram_when_collaboration_exist_in_bpmn_file() {
+        BPMNDiagramRichBuilder builder = newBuildFromBpmnFile("src/test/resources/bpmn/01-startEvent.bpmn.xml");
+
+        BPMNDiagram bpmnDiagram = builder.initializeBPMNDiagram();
+        BPMNPlane bpmnPlane = check(bpmnDiagram);
+
+        Map<QName, String> attributes = bpmnPlane.getOtherAttributes();
+        assertThat(attributes).containsValues("Collaboration_1cajy2f");
+    }
+
+    @Test
+    public void initializeBPMNDiagram_when_collaboration_not_exist_in_bpmn_file() {
+        BPMNDiagramRichBuilder builder = newBuildFromBpmnFile("src/test/resources/bpmn/02-startEvent_task_endEvent-without-collaboration.bpmn.xml");
+
+        BPMNDiagram bpmnDiagram = builder.initializeBPMNDiagram();
+        BPMNPlane bpmnPlane = check(bpmnDiagram);
+
+        Map<QName, String> attributes = bpmnPlane.getOtherAttributes();
+        assertThat(attributes).containsValues("process_1");
+    }
+
+    // always set like this
+    private static BPMNPlane check(BPMNDiagram bpmnDiagram) {
+        assertThat(bpmnDiagram.getId()).isEqualTo("BPMNDiagram_1");
+        BPMNPlane bpmnPlane = bpmnDiagram.getBPMNPlane();
+        assertThat(bpmnPlane.getId()).isEqualTo("BPMNPlane_1");
+        return bpmnPlane;
+    }
+
+    private static BPMNDiagramRichBuilder newBuildFromBpmnFile(String bpmnFilePath) {
+        return new BPMNDiagramRichBuilder(definitionsFromBpmnFile(bpmnFilePath));
+    }
+
+    private static TDefinitions definitionsFromBpmnFile(String bpmnFilePath) {
+        return defaultBpmnInOut().readFromBpmn(new File(bpmnFilePath));
+    }
+
+}

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/internal/SemanticTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/internal/SemanticTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.process.analytics.tools.bpmn.generator.internal;
 
 import io.process.analytics.tools.bpmn.generator.internal.model.TDefinitions;

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/internal/SemanticTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/internal/SemanticTest.java
@@ -15,14 +15,15 @@
  */
 package io.process.analytics.tools.bpmn.generator.internal;
 
-import io.process.analytics.tools.bpmn.generator.internal.model.TDefinitions;
-import io.process.analytics.tools.bpmn.generator.internal.model.TProcess;
-import org.junit.jupiter.api.Test;
+import static io.process.analytics.tools.bpmn.generator.internal.BpmnInOut.defaultBpmnInOut;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 
-import static io.process.analytics.tools.bpmn.generator.internal.BpmnInOut.defaultBpmnInOut;
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.Test;
+
+import io.process.analytics.tools.bpmn.generator.internal.generated.model.TDefinitions;
+import io.process.analytics.tools.bpmn.generator.internal.generated.model.TProcess;
 
 class SemanticTest {
 

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/internal/SemanticTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/internal/SemanticTest.java
@@ -1,0 +1,32 @@
+package io.process.analytics.tools.bpmn.generator.internal;
+
+import io.process.analytics.tools.bpmn.generator.internal.model.TDefinitions;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static io.process.analytics.tools.bpmn.generator.internal.BpmnInOut.defaultBpmnInOut;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SemanticTest {
+
+    @Test
+    public void detect_collaboration_when_exist_in_bpmn_file() {
+        Semantic semantic = semanticFromBpmnFile("src/test/resources/bpmn/01-startEvent.bpmn.xml");
+        assertThat(semantic.getCollaboration())
+                .get()
+                .hasFieldOrPropertyWithValue("id", "Collaboration_1cajy2f");
+    }
+
+    @Test
+    public void detect_collaboration_when_not_exist_in_bpmn_file() {
+        Semantic semantic = semanticFromBpmnFile("src/test/resources/bpmn/02-startEvent_task_endEvent-without-collaboration.bpmn.xml");
+        assertThat(semantic.getCollaboration()).isEmpty();
+    }
+
+    private static Semantic semanticFromBpmnFile(String bpmnFilePath) {
+        TDefinitions tDefinitions = defaultBpmnInOut().readFromBpmn(new File(bpmnFilePath));
+        return new Semantic(tDefinitions);
+    }
+
+}

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/internal/SemanticTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/internal/SemanticTest.java
@@ -1,6 +1,7 @@
 package io.process.analytics.tools.bpmn.generator.internal;
 
 import io.process.analytics.tools.bpmn.generator.internal.model.TDefinitions;
+import io.process.analytics.tools.bpmn.generator.internal.model.TProcess;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -22,6 +23,14 @@ class SemanticTest {
     public void detect_collaboration_when_not_exist_in_bpmn_file() {
         Semantic semantic = semanticFromBpmnFile("src/test/resources/bpmn/02-startEvent_task_endEvent-without-collaboration.bpmn.xml");
         assertThat(semantic.getCollaboration()).isEmpty();
+    }
+
+    @Test
+    public void detect_processes_in_bpmn_file() {
+        Semantic semantic = semanticFromBpmnFile("src/test/resources/bpmn/01-startEvent.bpmn.xml");
+        assertThat(semantic.getProcesses())
+                .hasSize(1)
+                .extracting(TProcess::getId).containsExactly("Process_1duwsyj");
     }
 
     private static Semantic semanticFromBpmnFile(String bpmnFilePath) {

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/internal/XmlParserTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/internal/XmlParserTest.java
@@ -31,7 +31,7 @@ public class XmlParserTest {
     private final XmlParser xmlParser = new XmlParser();
 
     @Test
-    public void unmarshall() throws IOException, ClassNotFoundException {
+    public void unmarshall() throws IOException {
         String bpmnAsXml = fileContent("src/test/resources/bpmn/01-startEvent.bpmn.xml");
 
         TDefinitions definitions = xmlParser.unmarshall(bpmnAsXml);

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/internal/XmlParserTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/internal/XmlParserTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.process.analytics.tools.bpmn.generator.internal;
+
+import io.process.analytics.tools.bpmn.generator.internal.model.BPMNDiagram;
+import io.process.analytics.tools.bpmn.generator.internal.model.BPMNPlane;
+import io.process.analytics.tools.bpmn.generator.internal.model.TDefinitions;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class XmlParserTest {
+
+    private final XmlParser xmlParser = new XmlParser();
+
+    @Test
+    public void unmarshall() {
+        String xmlString = "";
+        TDefinitions definitions = xmlParser.unmarshall(xmlString);
+
+        List<BPMNDiagram> diagram = definitions.getBPMNDiagram();
+        assertThat(diagram)
+                .hasSize(1)
+                .extracting(BPMNDiagram::getId).isEqualTo("BPMNDiagram_1");
+        BPMNPlane plane = diagram.get(0).getBPMNPlane();
+        assertThat(plane.getId()).isEqualTo("12");
+    }
+
+}

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/internal/XmlParserTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/internal/XmlParserTest.java
@@ -15,16 +15,18 @@
  */
 package io.process.analytics.tools.bpmn.generator.internal;
 
-import io.process.analytics.tools.bpmn.generator.internal.model.*;
-import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
 
-import javax.xml.bind.JAXBElement;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import javax.xml.bind.JAXBElement;
+
+import org.junit.jupiter.api.Test;
+
+import io.process.analytics.tools.bpmn.generator.internal.generated.model.*;
 
 public class XmlParserTest {
 

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/internal/XmlParserTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/internal/XmlParserTest.java
@@ -15,11 +15,10 @@
  */
 package io.process.analytics.tools.bpmn.generator.internal;
 
-import io.process.analytics.tools.bpmn.generator.internal.model.BPMNDiagram;
-import io.process.analytics.tools.bpmn.generator.internal.model.BPMNPlane;
-import io.process.analytics.tools.bpmn.generator.internal.model.TDefinitions;
+import io.process.analytics.tools.bpmn.generator.internal.model.*;
 import org.junit.Test;
 
+import javax.xml.bind.JAXBElement;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -32,11 +31,22 @@ public class XmlParserTest {
     private final XmlParser xmlParser = new XmlParser();
 
     @Test
-    public void unmarshall() throws IOException {
+    public void unmarshall() throws IOException, ClassNotFoundException {
         String bpmnAsXml = fileContent("src/test/resources/bpmn/01-startEvent.bpmn.xml");
 
         TDefinitions definitions = xmlParser.unmarshall(bpmnAsXml);
 
+        // Semantic
+        List<JAXBElement<? extends TRootElement>> rootElement = definitions.getRootElement();
+        //rootElement.forEach(jaxbElement -> System.out.println(jaxbElement.getValue().getClass()));
+        assertThat(rootElement)
+                .hasSize(2)
+                .extracting(JAXBElement::getValue)
+                .extracting(TRootElement::getClass)
+                .extracting(Class::getName)
+                .containsExactly(TCollaboration.class.getName(),TProcess.class.getName());
+
+        // Shapes
         List<BPMNDiagram> diagram = definitions.getBPMNDiagram();
         assertThat(diagram)
                 .hasSize(1)

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/internal/XmlParserTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/internal/XmlParserTest.java
@@ -16,7 +16,7 @@
 package io.process.analytics.tools.bpmn.generator.internal;
 
 import io.process.analytics.tools.bpmn.generator.internal.model.*;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 import javax.xml.bind.JAXBElement;
 import java.io.File;

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/internal/XmlParserTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/internal/XmlParserTest.java
@@ -20,6 +20,9 @@ import io.process.analytics.tools.bpmn.generator.internal.model.BPMNPlane;
 import io.process.analytics.tools.bpmn.generator.internal.model.TDefinitions;
 import org.junit.Test;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -29,16 +32,23 @@ public class XmlParserTest {
     private final XmlParser xmlParser = new XmlParser();
 
     @Test
-    public void unmarshall() {
-        String xmlString = "";
-        TDefinitions definitions = xmlParser.unmarshall(xmlString);
+    public void unmarshall() throws IOException {
+        String bpmnAsXml = fileContent("src/test/resources/bpmn/01-startEvent.bpmn.xml");
+
+        TDefinitions definitions = xmlParser.unmarshall(bpmnAsXml);
 
         List<BPMNDiagram> diagram = definitions.getBPMNDiagram();
         assertThat(diagram)
                 .hasSize(1)
-                .extracting(BPMNDiagram::getId).isEqualTo("BPMNDiagram_1");
+                .extracting(BPMNDiagram::getId).containsOnly("BPMNDiagram_1");
         BPMNPlane plane = diagram.get(0).getBPMNPlane();
-        assertThat(plane.getId()).isEqualTo("12");
+        assertThat(plane.getId()).isEqualTo("BPMNPlane_1");
+    }
+
+    private static String fileContent(String filePath) throws IOException {
+        String bpmnAsXml = Files.readString(new File(filePath).toPath());
+        //System.out.println("xml: " + bpmnAsXml);
+        return bpmnAsXml;
     }
 
 }

--- a/java/src/test/resources/bpmn/01-startEvent.bpmn.xml
+++ b/java/src/test/resources/bpmn/01-startEvent.bpmn.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright 2020 Bonitasoft S.A.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<bpmn:definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_12nbmjq" targetNamespace="http://modeler.bpmn/schema/bpmn">
+    <bpmn:collaboration id="Collaboration_1cajy2f">
+        <bpmn:participant id="Participant_0zyusbn" name="Pool" processRef="Process_1duwsyj" />
+    </bpmn:collaboration>
+    <bpmn:process id="Process_1duwsyj" isExecutable="false">
+        <bpmn:startEvent id="StartEvent_05jmofc" name="début">
+            <bpmn:outgoing>Flow_1bic2fy</bpmn:outgoing>
+        </bpmn:startEvent>
+    </bpmn:process>
+    <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+        <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Collaboration_1cajy2f">
+            <bpmndi:BPMNShape id="Participant_0zyusbn_di" bpmnElement="Participant_0zyusbn" isHorizontal="true">
+                <dc:Bounds x="152" y="39" width="760" height="121" />
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_05jmofc">
+                <dc:Bounds x="206" y="81" width="36" height="36" />
+                <bpmndi:BPMNLabel>
+                    <dc:Bounds x="210" y="124" width="28" height="14" />
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+        </bpmndi:BPMNPlane>
+    </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/java/src/test/resources/bpmn/01-startEvent.bpmn.xml
+++ b/java/src/test/resources/bpmn/01-startEvent.bpmn.xml
@@ -19,7 +19,7 @@
         <bpmn:participant id="Participant_0zyusbn" name="Pool" processRef="Process_1duwsyj" />
     </bpmn:collaboration>
     <bpmn:process id="Process_1duwsyj" isExecutable="false">
-        <bpmn:startEvent id="StartEvent_05jmofc" name="début">
+        <bpmn:startEvent id="StartEvent_05jmofc" name="Start">
             <bpmn:outgoing>Flow_1bic2fy</bpmn:outgoing>
         </bpmn:startEvent>
     </bpmn:process>

--- a/java/src/test/resources/bpmn/02-startEvent_task_endEvent-without-collaboration.bpmn.xml
+++ b/java/src/test/resources/bpmn/02-startEvent_task_endEvent-without-collaboration.bpmn.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="ISO-8859-1" standalone="yes"?>
+<semantic:definitions id="semantic_1" name="simplified A.1.0" targetNamespace="http://www.trisotech.com/definitions/_1373649849716" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:semantic="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <semantic:process isExecutable="false" id="process_1">
+        <semantic:startEvent name="Start Event" id="startEvent_1">
+            <semantic:outgoing>task_1</semantic:outgoing>
+        </semantic:startEvent>
+        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 1" id="task_1">
+            <semantic:incoming>startEvent_1</semantic:incoming>
+            <semantic:outgoing>endEvent_1</semantic:outgoing>
+        </semantic:task>
+        <semantic:endEvent name="End Event" id="endEvent_1">
+            <semantic:incoming>task_1</semantic:incoming>
+        </semantic:endEvent>
+        <semantic:sequenceFlow sourceRef="startEvent_1" targetRef="task_1" name="" id="sequenceFlow_1"/>
+        <semantic:sequenceFlow sourceRef="task_1" targetRef="endEvent_1" name="" id="sequenceFlow_2"/>
+    </semantic:process>
+    <bpmndi:BPMNDiagram documentation="" id="BPMNDiagram_1" name="A.1.0" resolution="96.00000267028808">
+        <bpmndi:BPMNPlane bpmnElement="process_1">
+            <bpmndi:BPMNShape bpmnElement="startEvent_1" id="shape_startEvent_1">
+                <dc:Bounds height="30.0" width="30.0" x="186.0" y="336.0"/>
+                <bpmndi:BPMNLabel labelStyle="labelStyle_1">
+                    <dc:Bounds height="12.804751171875008" width="94.93333333333335" x="153.67766754457273" y="371.3333333333333"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="task_1" id="shape_task_1">
+                <dc:Bounds height="68.0" width="83.0" x="258.0" y="317.0"/>
+                <bpmndi:BPMNLabel labelStyle="labelStyle_1">
+                    <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="263.3333333333333" y="344.5818763825664"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="endEvent_1" id="shape_endEvent_1">
+                <dc:Bounds height="68.0" width="83.0" x="390.0" y="317.0"/>
+                <bpmndi:BPMNLabel labelStyle="labelStyle_1">
+                    <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="395.3333333333333" y="344.5818763825664"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge bpmnElement="sequenceFlow_1" id="shape_sequenceFlow_1">
+                <di:waypoint x="342.0" y="351.0"/>
+                <di:waypoint x="390.0" y="351.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="sequenceFlow_2" id="shape_sequenceFlow_2">
+                <di:waypoint x="216.0" y="351.0"/>
+                <di:waypoint x="234.0" y="351.0"/>
+                <di:waypoint x="258.0" y="351.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+        <bpmndi:BPMNLabelStyle id="labelStyle_1">
+            <dc:Font isBold="false" isItalic="false" isStrikeThrough="false" isUnderline="false" name="Arial" size="11.0"/>
+        </bpmndi:BPMNLabelStyle>
+    </bpmndi:BPMNDiagram>
+</semantic:definitions>
+

--- a/java/src/test/resources/bpmn/A.2.0.bpmn.xml
+++ b/java/src/test/resources/bpmn/A.2.0.bpmn.xml
@@ -1,0 +1,157 @@
+<?xml version="1.0" encoding="ISO-8859-1" standalone="yes"?>
+<semantic:definitions id="_1373649889746" name="A.2.0" targetNamespace="http://www.trisotech.com/definitions/_1373649889746" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:bpsim="http://www.bpsim.org/schemas/1.0" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:semantic="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <semantic:process isExecutable="false" id="WFP-6-">
+        <semantic:startEvent name="Start Event" id="_6b5db6a9-037a-49ad-9201-09201e2aaa97">
+            <semantic:outgoing>_b50f530c-3450-4e1a-b81f-ea346dc6e1cb</semantic:outgoing>
+        </semantic:startEvent>
+        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 1" id="_5a972b87-735d-454a-b31c-f52fb3afc5c7">
+            <semantic:incoming>_b50f530c-3450-4e1a-b81f-ea346dc6e1cb</semantic:incoming>
+            <semantic:outgoing>_fe74c141-8843-4b00-a704-5e5e13be53b0</semantic:outgoing>
+        </semantic:task>
+        <semantic:endEvent name="End Event" id="_258f51eb-b764-4a71-b681-3a01cca14143">
+            <semantic:incoming>_a3d40a56-9b7f-417e-911e-d39e7f18b90c</semantic:incoming>
+            <semantic:incoming>_d4ce87c6-1373-45d6-a3b4-fbb2a04ee2e5</semantic:incoming>
+        </semantic:endEvent>
+        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 2" id="_4f7d62d7-f0e6-46bc-be00-69e02da38f65">
+            <semantic:incoming>_f1478fb7-98c4-4c01-8c15-68bd04c91535</semantic:incoming>
+            <semantic:outgoing>_a3d40a56-9b7f-417e-911e-d39e7f18b90c</semantic:outgoing>
+        </semantic:task>
+        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 3" id="_e6eb725a-34bc-45c7-aed0-9f9596cd7bee">
+            <semantic:incoming>_a1570a53-28d2-41b1-a3a2-3e50c00d747e</semantic:incoming>
+            <semantic:outgoing>_e9ebc7c7-995d-46db-86ce-d823bc2b4687</semantic:outgoing>
+        </semantic:task>
+        <semantic:exclusiveGateway gatewayDirection="Unspecified" name="Gateway&#10;(Split Flow)" id="_35fe57a7-1302-44e2-bf58-032f11af7ecb">
+            <semantic:incoming>_fe74c141-8843-4b00-a704-5e5e13be53b0</semantic:incoming>
+            <semantic:outgoing>_f1478fb7-98c4-4c01-8c15-68bd04c91535</semantic:outgoing>
+            <semantic:outgoing>_a1570a53-28d2-41b1-a3a2-3e50c00d747e</semantic:outgoing>
+            <semantic:outgoing>_20ebb3c1-5178-4c7c-a91d-23e58f2aa73b</semantic:outgoing>
+        </semantic:exclusiveGateway>
+        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 4" id="_7d399717-1aba-47ac-8d7d-8aaa033255e0">
+            <semantic:incoming>_20ebb3c1-5178-4c7c-a91d-23e58f2aa73b</semantic:incoming>
+            <semantic:outgoing>_698b593f-18eb-42ea-b8cd-bcd51e1514cc</semantic:outgoing>
+        </semantic:task>
+        <semantic:exclusiveGateway gatewayDirection="Unspecified" name="Gateway&#10;(Merge Flows)" id="_33c66216-391c-49c2-aa19-d8f0b7f5f91d">
+            <semantic:incoming>_e9ebc7c7-995d-46db-86ce-d823bc2b4687</semantic:incoming>
+            <semantic:incoming>_698b593f-18eb-42ea-b8cd-bcd51e1514cc</semantic:incoming>
+            <semantic:outgoing>_d4ce87c6-1373-45d6-a3b4-fbb2a04ee2e5</semantic:outgoing>
+        </semantic:exclusiveGateway>
+        <semantic:sequenceFlow sourceRef="_6b5db6a9-037a-49ad-9201-09201e2aaa97" targetRef="_5a972b87-735d-454a-b31c-f52fb3afc5c7" name="" id="_b50f530c-3450-4e1a-b81f-ea346dc6e1cb"/>
+        <semantic:sequenceFlow sourceRef="_5a972b87-735d-454a-b31c-f52fb3afc5c7" targetRef="_35fe57a7-1302-44e2-bf58-032f11af7ecb" name="" id="_fe74c141-8843-4b00-a704-5e5e13be53b0"/>
+        <semantic:sequenceFlow sourceRef="_35fe57a7-1302-44e2-bf58-032f11af7ecb" targetRef="_4f7d62d7-f0e6-46bc-be00-69e02da38f65" name="" id="_f1478fb7-98c4-4c01-8c15-68bd04c91535"/>
+        <semantic:sequenceFlow sourceRef="_4f7d62d7-f0e6-46bc-be00-69e02da38f65" targetRef="_258f51eb-b764-4a71-b681-3a01cca14143" name="" id="_a3d40a56-9b7f-417e-911e-d39e7f18b90c"/>
+        <semantic:sequenceFlow sourceRef="_e6eb725a-34bc-45c7-aed0-9f9596cd7bee" targetRef="_33c66216-391c-49c2-aa19-d8f0b7f5f91d" name="" id="_e9ebc7c7-995d-46db-86ce-d823bc2b4687"/>
+        <semantic:sequenceFlow sourceRef="_7d399717-1aba-47ac-8d7d-8aaa033255e0" targetRef="_33c66216-391c-49c2-aa19-d8f0b7f5f91d" name="" id="_698b593f-18eb-42ea-b8cd-bcd51e1514cc"/>
+        <semantic:sequenceFlow sourceRef="_33c66216-391c-49c2-aa19-d8f0b7f5f91d" targetRef="_258f51eb-b764-4a71-b681-3a01cca14143" name="" id="_d4ce87c6-1373-45d6-a3b4-fbb2a04ee2e5"/>
+        <semantic:sequenceFlow sourceRef="_35fe57a7-1302-44e2-bf58-032f11af7ecb" targetRef="_e6eb725a-34bc-45c7-aed0-9f9596cd7bee" name="" id="_a1570a53-28d2-41b1-a3a2-3e50c00d747e"/>
+        <semantic:sequenceFlow sourceRef="_35fe57a7-1302-44e2-bf58-032f11af7ecb" targetRef="_7d399717-1aba-47ac-8d7d-8aaa033255e0" name="" id="_20ebb3c1-5178-4c7c-a91d-23e58f2aa73b"/>
+    </semantic:process>
+    <bpmndi:BPMNDiagram documentation="" id="Trisotech_Visio-_6" name="A.2.0" resolution="96.00000267028808">
+        <bpmndi:BPMNPlane bpmnElement="WFP-6-">
+            <bpmndi:BPMNShape bpmnElement="_6b5db6a9-037a-49ad-9201-09201e2aaa97" id="S1373649889871__6b5db6a9-037a-49ad-9201-09201e2aaa97">
+                <dc:Bounds height="30.0" width="30.0" x="186.0" y="276.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373649889872">
+                    <dc:Bounds height="12.804751171875008" width="94.93333333333335" x="153.67766754457273" y="311.3333333333333"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_5a972b87-735d-454a-b31c-f52fb3afc5c7" id="S1373649889873__5a972b87-735d-454a-b31c-f52fb3afc5c7">
+                <dc:Bounds height="68.0" width="83.0" x="252.0" y="257.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373649889872">
+                    <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="257.3333333333333" y="284.5818763825664"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_258f51eb-b764-4a71-b681-3a01cca14143" id="S1373649889874__258f51eb-b764-4a71-b681-3a01cca14143">
+                <dc:Bounds height="32.0" width="32.0" x="736.0" y="244.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373649889872">
+                    <dc:Bounds height="12.804751171875008" width="94.93333333333335" x="656.5963254593175" y="257.5976244140626"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_4f7d62d7-f0e6-46bc-be00-69e02da38f65" id="S1373649889875__4f7d62d7-f0e6-46bc-be00-69e02da38f65">
+                <dc:Bounds height="68.0" width="83.0" x="480.0" y="172.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373649889872">
+                    <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="485.3333333333333" y="199.58187638256646"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_e6eb725a-34bc-45c7-aed0-9f9596cd7bee" id="S1373649889876__e6eb725a-34bc-45c7-aed0-9f9596cd7bee">
+                <dc:Bounds height="68.0" width="83.0" x="480.0" y="257.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373649889872">
+                    <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="485.3333333333333" y="284.5818763825664"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_35fe57a7-1302-44e2-bf58-032f11af7ecb" isMarkerVisible="false" id="S1373649889877__35fe57a7-1302-44e2-bf58-032f11af7ecb">
+                <dc:Bounds height="42.0" width="42.0" x="399.0" y="270.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373649889872">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="336.7931758530184" y="311.26591304208245"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_7d399717-1aba-47ac-8d7d-8aaa033255e0" id="S1373649889878__7d399717-1aba-47ac-8d7d-8aaa033255e0">
+                <dc:Bounds height="68.0" width="83.0" x="480.0" y="352.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373649889872">
+                    <dc:Bounds height="12.804751171875008" width="72.48293963254594" x="485.3333333333333" y="379.5818763825664"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNShape bpmnElement="_33c66216-391c-49c2-aa19-d8f0b7f5f91d" isMarkerVisible="false" id="S1373649889879__33c66216-391c-49c2-aa19-d8f0b7f5f91d">
+                <dc:Bounds height="42.0" width="42.0" x="621.0" y="315.0"/>
+                <bpmndi:BPMNLabel labelStyle="LS1373649889872">
+                    <dc:Bounds height="25.604702343750013" width="94.93333333333335" x="654.3207349081365" y="347.41024725332187"/>
+                </bpmndi:BPMNLabel>
+            </bpmndi:BPMNShape>
+            <bpmndi:BPMNEdge bpmnElement="_a3d40a56-9b7f-417e-911e-d39e7f18b90c" id="E1373649889881__a3d40a56-9b7f-417e-911e-d39e7f18b90c">
+                <di:waypoint x="563.0" y="206.0"/>
+                <di:waypoint x="752.0" y="206.0"/>
+                <di:waypoint x="752.0" y="244.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_b50f530c-3450-4e1a-b81f-ea346dc6e1cb" id="E1373649889882__b50f530c-3450-4e1a-b81f-ea346dc6e1cb">
+                <di:waypoint x="216.0" y="291.0"/>
+                <di:waypoint x="234.0" y="291.0"/>
+                <di:waypoint x="252.0" y="291.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_fe74c141-8843-4b00-a704-5e5e13be53b0" id="E1373649889883__fe74c141-8843-4b00-a704-5e5e13be53b0">
+                <di:waypoint x="335.0" y="291.0"/>
+                <di:waypoint x="353.0" y="291.0"/>
+                <di:waypoint x="399.0" y="291.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_20ebb3c1-5178-4c7c-a91d-23e58f2aa73b" id="E1373649889884__20ebb3c1-5178-4c7c-a91d-23e58f2aa73b">
+                <di:waypoint x="420.0" y="312.0"/>
+                <di:waypoint x="420.0" y="386.0"/>
+                <di:waypoint x="480.0" y="386.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_d4ce87c6-1373-45d6-a3b4-fbb2a04ee2e5" id="E1373649889885__d4ce87c6-1373-45d6-a3b4-fbb2a04ee2e5">
+                <di:waypoint x="663.0" y="336.0"/>
+                <di:waypoint x="752.0" y="336.0"/>
+                <di:waypoint x="752.0" y="276.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_e9ebc7c7-995d-46db-86ce-d823bc2b4687" id="E1373649889886__e9ebc7c7-995d-46db-86ce-d823bc2b4687">
+                <di:waypoint x="563.0" y="291.0"/>
+                <di:waypoint x="642.0" y="291.0"/>
+                <di:waypoint x="642.0" y="315.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_f1478fb7-98c4-4c01-8c15-68bd04c91535" id="E1373649889887__f1478fb7-98c4-4c01-8c15-68bd04c91535">
+                <di:waypoint x="420.0" y="270.0"/>
+                <di:waypoint x="420.0" y="206.0"/>
+                <di:waypoint x="480.0" y="206.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_a1570a53-28d2-41b1-a3a2-3e50c00d747e" id="E1373649889888__a1570a53-28d2-41b1-a3a2-3e50c00d747e">
+                <di:waypoint x="440.0" y="291.0"/>
+                <di:waypoint x="458.0" y="291.0"/>
+                <di:waypoint x="480.0" y="291.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+            <bpmndi:BPMNEdge bpmnElement="_698b593f-18eb-42ea-b8cd-bcd51e1514cc" id="E1373649889889__698b593f-18eb-42ea-b8cd-bcd51e1514cc">
+                <di:waypoint x="563.0" y="386.0"/>
+                <di:waypoint x="642.0" y="386.0"/>
+                <di:waypoint x="642.0" y="357.0"/>
+                <bpmndi:BPMNLabel/>
+            </bpmndi:BPMNEdge>
+        </bpmndi:BPMNPlane>
+        <bpmndi:BPMNLabelStyle id="LS1373649889872">
+            <dc:Font isBold="false" isItalic="false" isStrikeThrough="false" isUnderline="false" name="Arial" size="11.0"/>
+        </bpmndi:BPMNLabelStyle>
+    </bpmndi:BPMNDiagram>
+</semantic:definitions>


### PR DESCRIPTION
This includes
- internal bpmn model: generated from xsd using `jaxb`
- an initial abstraction of this model and helpers/builders classes to manipulate it
- tooling to replace/create the `BPMNDiagram` part of the model by a generated one. Currently
  - we only create the `BPMNDiagram` and its `BPMNPlane`
  - the `BPMNPlane` bpmelement is set correctly whether or not a semantic/model `collaboration` element exists
  - a canvas to add nodes/edges to the generated `BPMNDiagram`