### PR TITLE
feat(converter): transform bpmn model into algorithms model

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -50,7 +50,7 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.14.0</version>
+            <version>3.15.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/App.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/App.java
@@ -44,16 +44,22 @@ public class App {
 
         App app = new App();
         LayoutSortedDiagram diagram = app.loadAndLayout(bpmnInputFile);
-        
-        // TODO implement export type selection in a better way
-        if (args.length > 2 && !"bpmn".equals(args[2])) {
-            if ("svg".equals(args[2])) {
-                app.exportToSvg(diagram, outputFile);
-            } else {
+
+        FileUtils.touch(outputFile);
+        String exportType = exportType(args);
+        log("Requested Export Type: " + exportType);
+        switch (exportType) {
+            case "ascii":
                 app.exportToAscii(diagram, outputFile);
-            }
-        } else {
-            app.exportToBpmn(null);
+                break;
+            case "bpmn":
+                app.exportToBpmn(null);
+                break;
+            case "svg":
+                app.exportToSvg(diagram, outputFile);
+                break;
+            default:
+                throw new IllegalStateException("Unexpected Export Type: " + exportType);
         }
     }
 
@@ -61,6 +67,14 @@ public class App {
         if (args.length <= 1) {
             throw new IllegalArgumentException("You must pass at least 2 arguments.");
         }
+    }
+
+    private static String exportType(String[] args) {
+        String type = "bpmn";
+        if (args.length > 2) {
+            type = args[2];
+        }
+        return type;
     }
 
     private static void log(String message) {
@@ -106,7 +120,6 @@ public class App {
     private void exportToSvg(LayoutSortedDiagram diagram, File outputFile) throws IOException {
         log("Exporting to SVG");
         byte[] svgContent = new SVGExporter().export(diagram.getGrid(), diagram.getSortedDiagram());
-        FileUtils.touch(outputFile);
         Files.write(outputFile.toPath(), svgContent);
         log("SVG exported to " + outputFile);
     }

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/App.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/App.java
@@ -44,8 +44,17 @@ public class App {
 
         App app = new App();
         LayoutSortedDiagram diagram = app.loadAndLayout(bpmnInputFile);
-        app.exportToSvg(diagram, outputFile);
-//        app.exportToAsciiTxt(diagram, outputFile);
+        
+        // TODO implement export type selection in a better way
+        if (args.length > 2 && !"bpmn".equals(args[2])) {
+            if ("svg".equals(args[2])) {
+                app.exportToSvg(diagram, outputFile);
+            } else {
+                app.exportToAscii(diagram, outputFile);
+            }
+        } else {
+            app.exportToBpmn(null);
+        }
     }
 
     private static void validate(String[] args) {
@@ -84,14 +93,15 @@ public class App {
         return new LayoutSortedDiagram(grid, sortedDiagram);
     }
 
-    //    private void exportBpmn(TDefinitions tDefinitions) {
-    //        log("Building bpmn diagram elements");
-    //        TDefinitions builtDefinitions = new BPMNDiagramRichBuilder(tDefinitions).build();
-    //        log("Bpmn diagram elements have been built");
-    //        File outputBpmnFile = new File(args[1]);
-    //        bpmnInOut.writeToBpmnFile(builtDefinitions, outputBpmnFile);
-    //        log("New file with bpmn diagram generated to " + outputBpmnFile.getAbsolutePath());
-    //    }
+    private void exportToBpmn(TDefinitions tDefinitions) {
+        log("export to bpmn NOT IMPLEMENTED");
+//        log("Building bpmn diagram elements");
+//        TDefinitions builtDefinitions = new BPMNDiagramRichBuilder(tDefinitions).build();
+//        log("Bpmn diagram elements have been built");
+//        File outputBpmnFile = new File(args[1]);
+//        bpmnInOut.writeToBpmnFile(builtDefinitions, outputBpmnFile);
+//        log("New file with bpmn diagram generated to " + outputBpmnFile.getAbsolutePath());
+    }
 
     private void exportToSvg(LayoutSortedDiagram diagram, File outputFile) throws IOException {
         log("Exporting to SVG");
@@ -101,11 +111,11 @@ public class App {
         log("SVG exported to " + outputFile);
     }
 
-    private void exportToAsciiTxt(LayoutSortedDiagram diagram, File outputFile) throws IOException {
-        log("Exporting to ASCII text file");
+    private void exportToAscii(LayoutSortedDiagram diagram, File outputFile) throws IOException {
+        log("Exporting to ASCII file");
         String asciiContent = new ASCIIExporter().export(diagram.getGrid());
         Files.write(outputFile.toPath(), asciiContent.getBytes(StandardCharsets.UTF_8));
-        log("ASCII text exported to " + outputFile);
+        log("ASCII exported to " + outputFile);
     }
 
 }

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/App.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/App.java
@@ -17,69 +17,35 @@ package io.process.analytics.tools.bpmn.generator;
 import static io.process.analytics.tools.bpmn.generator.internal.BpmnInOut.defaultBpmnInOut;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 
-import io.process.analytics.tools.bpmn.generator.internal.BPMNDiagramRichBuilder;
+import io.process.analytics.tools.bpmn.generator.algo.ShapeLayouter;
+import io.process.analytics.tools.bpmn.generator.algo.ShapeSorter;
+import io.process.analytics.tools.bpmn.generator.converter.BpmnToAlgoModelConverter;
+import io.process.analytics.tools.bpmn.generator.export.ASCIIExporter;
+import io.process.analytics.tools.bpmn.generator.export.SVGExporter;
 import io.process.analytics.tools.bpmn.generator.internal.BpmnInOut;
+import io.process.analytics.tools.bpmn.generator.internal.FileUtils;
 import io.process.analytics.tools.bpmn.generator.internal.generated.model.TDefinitions;
+import io.process.analytics.tools.bpmn.generator.model.Diagram;
+import io.process.analytics.tools.bpmn.generator.model.Grid;
+import io.process.analytics.tools.bpmn.generator.model.SortedDiagram;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 public class App {
 
     public static void main(String[] args) throws Exception {
         validate(args);
-        String inputBpmnFilePath = args[0];
-        log("Loading bpmn file: " + inputBpmnFilePath);
-        BpmnInOut bpmnInOut = defaultBpmnInOut();
-        TDefinitions tDefinitions = bpmnInOut.readFromBpmn(new File(inputBpmnFilePath));
-        log("Loaded " + tDefinitions);
+        File bpmnInputFile = new File(args[0]);
+        File outputFile = new File(args[1]);
 
-        log("Building bpmn diagram elements");
-        TDefinitions builtDefinitions = new BPMNDiagramRichBuilder(tDefinitions).build();
-        log("Bpmn diagram elements have been built");
-        File outputBpmnFile = new File(args[1]);
-        bpmnInOut.writeToBpmnFile(builtDefinitions, outputBpmnFile);
-        log("New file with bpmn diagram generated to " + outputBpmnFile.getAbsolutePath());
-
-
-
-
-//        // This is an example usage of sort/layout algorithm + export to svg for testing purpose
-//        Shape start = shape("start");
-//        Shape step1 = shape("step1");
-//        Shape step2 = shape("step2");
-//        Shape step3 = shape("step3");
-//        Shape step4 = shape("step4");
-//        Shape step5 = shape("step5");
-//        Shape end = shape("end");
-//        Diagram diagram = Diagram.builder()
-//                .shape(step1)
-//                .shape(step3)
-//                .shape(step2)
-//                .shape(end)
-//                .shape(step4)
-//                .shape(step5)
-//                .shape(start)
-//                .edge(edge(start, step1))
-//                .edge(edge(step1, step2))
-//                .edge(edge(step3, step4))
-//                .edge(edge(step5, step4))
-//                .edge(edge(step2, step4))
-//                .edge(edge(step4, end))
-//                .build();
-//
-//
-//
-//        ShapeSorter shapeSorter = new ShapeSorter();
-//        ShapeLayouter shapeLayouter = new ShapeLayouter();
-//
-//        SortedDiagram sortedDiagram = shapeSorter.sort(diagram);
-//        Grid grid = shapeLayouter.layout(sortedDiagram);
-//
-//        SVGExporter svgExporter = new SVGExporter();
-//
-//        byte[] exportedFile = svgExporter.export(grid, sortedDiagram);
-//
-//        Files.write(Path.of("target", "test.svg"), exportedFile);
-
+        App app = new App();
+        LayoutSortedDiagram diagram = app.loadAndLayout(bpmnInputFile);
+        app.exportToSvg(diagram, outputFile);
+//        app.exportToAsciiTxt(diagram, outputFile);
     }
 
     private static void validate(String[] args) {
@@ -90,6 +56,56 @@ public class App {
 
     private static void log(String message) {
         System.out.println(message);
+    }
+
+    @RequiredArgsConstructor
+    @Getter
+    private static class LayoutSortedDiagram {
+
+        private final Grid grid;
+        private final SortedDiagram sortedDiagram;
+    }
+
+    public LayoutSortedDiagram loadAndLayout(File bpmnInputFile) {
+        log("Loading bpmn file: " + bpmnInputFile);
+        BpmnInOut bpmnInOut = defaultBpmnInOut();
+        TDefinitions definitions = bpmnInOut.readFromBpmn(bpmnInputFile);
+        log("Loaded " + definitions);
+
+        log("Converting BPMN into internal model");
+        Diagram diagram = new BpmnToAlgoModelConverter().toAlgoModel(definitions);
+        log("Conversion done");
+
+        log("Sorting and generating Layout");
+        SortedDiagram sortedDiagram = new ShapeSorter().sort(diagram);
+        Grid grid = new ShapeLayouter().layout(sortedDiagram);
+        log("Sort and Layout done");
+
+        return new LayoutSortedDiagram(grid, sortedDiagram);
+    }
+
+    //    private void exportBpmn(TDefinitions tDefinitions) {
+    //        log("Building bpmn diagram elements");
+    //        TDefinitions builtDefinitions = new BPMNDiagramRichBuilder(tDefinitions).build();
+    //        log("Bpmn diagram elements have been built");
+    //        File outputBpmnFile = new File(args[1]);
+    //        bpmnInOut.writeToBpmnFile(builtDefinitions, outputBpmnFile);
+    //        log("New file with bpmn diagram generated to " + outputBpmnFile.getAbsolutePath());
+    //    }
+
+    private void exportToSvg(LayoutSortedDiagram diagram, File outputFile) throws IOException {
+        log("Exporting to SVG");
+        byte[] svgContent = new SVGExporter().export(diagram.getGrid(), diagram.getSortedDiagram());
+        FileUtils.touch(outputFile);
+        Files.write(outputFile.toPath(), svgContent);
+        log("SVG exported to " + outputFile);
+    }
+
+    private void exportToAsciiTxt(LayoutSortedDiagram diagram, File outputFile) throws IOException {
+        log("Exporting to ASCII text file");
+        String asciiContent = new ASCIIExporter().export(diagram.getGrid());
+        Files.write(outputFile.toPath(), asciiContent.getBytes(StandardCharsets.UTF_8));
+        log("ASCII text exported to " + outputFile);
     }
 
 }

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/converter/BpmnToAlgoModelConverter.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/converter/BpmnToAlgoModelConverter.java
@@ -15,14 +15,40 @@
  */
 package io.process.analytics.tools.bpmn.generator.converter;
 
-import io.process.analytics.tools.bpmn.generator.internal.generated.model.TDefinitions;
+import io.process.analytics.tools.bpmn.generator.internal.Semantic;
+import io.process.analytics.tools.bpmn.generator.internal.generated.model.*;
 import io.process.analytics.tools.bpmn.generator.model.Diagram;
+import io.process.analytics.tools.bpmn.generator.model.Diagram.DiagramBuilder;
+import io.process.analytics.tools.bpmn.generator.model.Edge;
+import io.process.analytics.tools.bpmn.generator.model.Shape;
+
+import java.util.List;
 
 public class BpmnToAlgoModelConverter {
 
     public Diagram toAlgoModel(TDefinitions definitions) {
+        Semantic semantic = new Semantic(definitions);
+        DiagramBuilder diagram = Diagram.builder();
 
-        return null;
+        List<TProcess> processes = semantic.getProcesses();
+        for (TProcess process : processes) {
+            Semantic.BpmnElements bpmnElements = semantic.getBpmnElements(process);
+
+            bpmnElements.getFlowNodes().stream()
+                    .map(flowNode -> new Shape(flowNode.getId(), flowNode.getName()))
+                    .forEach(diagram::shape);
+
+            bpmnElements.getSequenceFlows().stream()
+                    .map(seqFlow -> new Edge(getId(seqFlow.getSourceRef()), getId(seqFlow.getTargetRef())))
+                    .forEach(diagram::edge);
+        }
+
+        return diagram.build();
+    }
+
+    // assuming this is a TBaseElement
+    private static String getId(Object object) {
+        return ((TBaseElement) object).getId();
     }
 
 }

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/converter/BpmnToAlgoModelConverter.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/converter/BpmnToAlgoModelConverter.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.process.analytics.tools.bpmn.generator.converter;
+
+import io.process.analytics.tools.bpmn.generator.internal.generated.model.TDefinitions;
+import io.process.analytics.tools.bpmn.generator.model.Diagram;
+
+public class BpmnToAlgoModelConverter {
+
+    public Diagram toAlgoModel(TDefinitions definitions) {
+
+        return null;
+    }
+
+}

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/BpmnInOut.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/BpmnInOut.java
@@ -15,6 +15,7 @@
  */
 package io.process.analytics.tools.bpmn.generator.internal;
 
+import static io.process.analytics.tools.bpmn.generator.internal.FileUtils.createParents;
 import static io.process.analytics.tools.bpmn.generator.internal.FileUtils.fileContent;
 
 import java.io.File;
@@ -48,9 +49,7 @@ public class BpmnInOut {
     }
 
     public void writeToBpmnFile(TDefinitions definitions, File file) {
-        // TODO file/folder creation
-        file.getParentFile().mkdirs();
-
+        createParents(file);
         xmlParser.marshal(definitions, file);
     }
 

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/FileUtils.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/FileUtils.java
@@ -29,4 +29,14 @@ public class FileUtils {
         return String.join("\n", strings);
     }
 
+    public static void createParents(File file) {
+        // TODO throw IOException if failure like commons-io
+        file.getParentFile().mkdirs();
+    }
+
+    public static void touch(File file) throws IOException {
+        createParents(file);
+        file.createNewFile();
+    }
+
 }

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/Semantic.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/Semantic.java
@@ -47,7 +47,7 @@ public class Semantic {
         List<TCollaboration> collaborations = definitions.getRootElement().stream()
                 .map(JAXBElement::getValue)
                 .filter(TCollaboration.class::isInstance)
-                .map(o -> (TCollaboration) o)
+                .map(TCollaboration.class::cast)
                 .collect(Collectors.toList());
 
         // TODO check at most 1 otherwise error
@@ -63,11 +63,12 @@ public class Semantic {
         return definitions.getRootElement().stream()
                 .map(JAXBElement::getValue)
                 .filter(TProcess.class::isInstance)
-                .map(o -> (TProcess) o)
+                .map(TProcess.class::cast)
                 .collect(Collectors.toList());
     }
 
-    public List<String> getBpmnElements(TProcess process) {
+    // TODO manage lanes
+    public BpmnElements getBpmnElements(TProcess process) {
         // TODO manage TLaneSet
 //        List<TLaneSet> laneSet = process.getLaneSet();
 //        // there is always a TLaneSet (see BPMN spec)
@@ -78,10 +79,27 @@ public class Semantic {
 
 
         List<JAXBElement<? extends TFlowElement>> flowElements = process.getFlowElement();
-        // TODO filter nodes and edges
+        List<? extends TFlowElement> flowNodes = flowElements.stream()
+                .map(JAXBElement::getValue)
+                .filter(TFlowNode.class::isInstance)
+                .map(TFlowNode.class::cast)
+                .collect(Collectors.toList());
 
+        List<? extends TSequenceFlow> sequenceFlows = flowElements.stream()
+                .map(JAXBElement::getValue)
+                .filter(TSequenceFlow.class::isInstance)
+                .map(TSequenceFlow.class::cast)
+                .collect(Collectors.toList());
 
-
-        return null;
+        return new BpmnElements(flowNodes, sequenceFlows);
     }
+
+    @RequiredArgsConstructor
+    @Getter
+    public static class BpmnElements {
+
+        private final List<? extends TFlowElement> flowNodes;
+        private final List<? extends TSequenceFlow> sequenceFlows;
+    }
+
 }

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/Semantic.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/internal/Semantic.java
@@ -22,10 +22,7 @@ import java.util.stream.Collectors;
 
 import javax.xml.bind.JAXBElement;
 
-import io.process.analytics.tools.bpmn.generator.internal.generated.model.TCollaboration;
-import io.process.analytics.tools.bpmn.generator.internal.generated.model.TDefinitions;
-import io.process.analytics.tools.bpmn.generator.internal.generated.model.TParticipant;
-import io.process.analytics.tools.bpmn.generator.internal.generated.model.TProcess;
+import io.process.analytics.tools.bpmn.generator.internal.generated.model.*;
 import lombok.Getter;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
@@ -70,4 +67,21 @@ public class Semantic {
                 .collect(Collectors.toList());
     }
 
+    public List<String> getBpmnElements(TProcess process) {
+        // TODO manage TLaneSet
+//        List<TLaneSet> laneSet = process.getLaneSet();
+//        // there is always a TLaneSet (see BPMN spec)
+//        List<TLane> lanes = laneSet.get(0).getLane();
+//        // TODO do this for all lanes
+//        // TODO have a look at childLaneSet
+//        List<JAXBElement<Object>> flowNodeRef = lanes.get(0).getFlowNodeRef();
+
+
+        List<JAXBElement<? extends TFlowElement>> flowElements = process.getFlowElement();
+        // TODO filter nodes and edges
+
+
+
+        return null;
+    }
 }

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/AppTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/AppTest.java
@@ -70,15 +70,19 @@ public class AppTest {
     }
 
     private static void generateToBpmn(String input, String output) throws Exception {
-        App.main(new String[] { input, output });
+        App.main(new String[] { input, output});
+    }
+
+    private static void generate(String input, String output, String exportType) throws Exception {
+        App.main(new String[] { input, output, exportType });
     }
 
     private static void generateToSvg(String input, String output) throws Exception {
-        App.main(new String[] { input, output, "svg" });
+        generate(input, output, "svg");
     }
 
     private static void generateToAscii(String input, String output) throws Exception {
-        App.main(new String[] { input, output, "ascii" });
+        generate(input, output, "ascii");
     }
 
 }

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/AppTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/AppTest.java
@@ -15,7 +15,7 @@
  */
 package io.process.analytics.tools.bpmn.generator;
 
-import io.process.analytics.tools.bpmn.generator.internal.FileUtils;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
@@ -26,34 +26,59 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class AppTest {
 
     @Test
+    @Disabled("not implemented yet")
     public void main_generates_xml_output_file() throws Exception {
         String outputPath = outputPath("A.2.0_with_diagram.bpmn.xml");
-        generate("src/test/resources/bpmn/A.2.0.bpmn.xml", outputPath);
+        generateToBpmn(inputPath("A.2.0.bpmn.xml"), outputPath);
 
-        assertThat(new File(outputPath)).exists().isFile();
+        File bpmnFile = new File(outputPath);
+        assertThat(bpmnFile).exists().isFile();
         // TODO add xml assertions (assertj and/or xmlunit)
+        assertThat(fileContent(bpmnFile)).contains("BPMN Baby!!");
     }
 
     @Test
     public void main_generates_svg_output_file() throws Exception {
         String outputPath = outputPath("A.2.0_with_diagram.bpmn.svg");
-        generate("src/test/resources/bpmn/A.2.0.bpmn.xml", outputPath);
+        generateToSvg(inputPath("A.2.0.bpmn.xml"), outputPath);
 
         File svgFile = new File(outputPath);
         assertThat(svgFile).exists().isFile();
         assertThat(fileContent(svgFile)).contains("<svg xmlns=\"http://www.w3.org/2000/svg\"");
     }
 
+    @Test
+    public void main_generates_ascii_output_file() throws Exception {
+        String outputPath = outputPath("02-startEvent_task_endEvent-without-collaboration.bpmn.txt");
+        generateToAscii(inputPath("02-startEvent_task_endEvent-without-collaboration.bpmn.xml"), outputPath);
+
+        File asciiFile = new File(outputPath);
+        assertThat(asciiFile).exists().isFile();
+        assertThat(fileContent(asciiFile)).contains("+---");
+    }
+
     // =================================================================================================================
     // UTILS
     // =================================================================================================================
+
+    private static String inputPath(String fileName) {
+        return "src/test/resources/bpmn/" + fileName;
+    }
 
     private static String outputPath(String fileName) {
         return "target/test/output/AppTest/" + fileName;
     }
 
-    private static void generate(String input, String output) throws Exception {
+    private static void generateToBpmn(String input, String output) throws Exception {
         App.main(new String[] { input, output });
+    }
+
+    private static void generateToSvg(String input, String output) throws Exception {
+        App.main(new String[] { input, output, "svg" });
+    }
+
+    private static void generateToAscii(String input, String output) throws Exception {
+        App.main(new String[] { input, output, "ascii" });
     }
 
 }

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/AppTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/AppTest.java
@@ -15,26 +15,42 @@
  */
 package io.process.analytics.tools.bpmn.generator;
 
+import io.process.analytics.tools.bpmn.generator.internal.FileUtils;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
 
+import static io.process.analytics.tools.bpmn.generator.internal.FileUtils.fileContent;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class AppTest {
 
     @Test
     public void main_generates_xml_output_file() throws Exception {
-        String output = "target/test/output/AppTest/A.2.0_with_diagram.bpmn.xml";
-        generate("src/test/resources/bpmn/A.2.0.bpmn.xml", output);
+        String outputPath = outputPath("A.2.0_with_diagram.bpmn.xml");
+        generate("src/test/resources/bpmn/A.2.0.bpmn.xml", outputPath);
 
-        assertThat(new File(output)).exists();
+        assertThat(new File(outputPath)).exists().isFile();
         // TODO add xml assertions (assertj and/or xmlunit)
+    }
+
+    @Test
+    public void main_generates_svg_output_file() throws Exception {
+        String outputPath = outputPath("A.2.0_with_diagram.bpmn.svg");
+        generate("src/test/resources/bpmn/A.2.0.bpmn.xml", outputPath);
+
+        File svgFile = new File(outputPath);
+        assertThat(svgFile).exists().isFile();
+        assertThat(fileContent(svgFile)).contains("<svg xmlns=\"http://www.w3.org/2000/svg\"");
     }
 
     // =================================================================================================================
     // UTILS
     // =================================================================================================================
+
+    private static String outputPath(String fileName) {
+        return "target/test/output/AppTest/" + fileName;
+    }
 
     private static void generate(String input, String output) throws Exception {
         App.main(new String[] { input, output });

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/converter/BpmnToAlgoModelConverterTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/converter/BpmnToAlgoModelConverterTest.java
@@ -20,9 +20,7 @@ import io.process.analytics.tools.bpmn.generator.model.Diagram;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.io.File;
-
-import static io.process.analytics.tools.bpmn.generator.internal.BpmnInOut.defaultBpmnInOut;
+import static io.process.analytics.tools.bpmn.generator.internal.SemanticTest.definitionsFromBpmnFile;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class BpmnToAlgoModelConverterTest {
@@ -41,17 +39,12 @@ class BpmnToAlgoModelConverterTest {
 //        </semantic:endEvent>
 //        <semantic:sequenceFlow sourceRef="startEvent_1" targetRef="task_1" name="" id="sequenceFlow_1"/>
 //        <semantic:sequenceFlow sourceRef="task_1" targetRef="endEvent_1" name="" id="sequenceFlow_2"/>
-        TDefinitions definitions = fromBpmnFile("src/test/resources/bpmn/02-startEvent_task_endEvent-without-collaboration.bpmn.xml");
+        TDefinitions definitions = definitionsFromBpmnFile("src/test/resources/bpmn/02-startEvent_task_endEvent-without-collaboration.bpmn.xml");
 
         Diagram diagram = new BpmnToAlgoModelConverter().toAlgoModel(definitions);
 
         assertThat(diagram).isNull();
 //        assertThat(diagram.getShapes()).hasSize(2);
-    }
-
-
-    private static TDefinitions fromBpmnFile(String bpmnFilePath) {
-        return defaultBpmnInOut().readFromBpmn(new File(bpmnFilePath));
     }
 
 }

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/converter/BpmnToAlgoModelConverterTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/converter/BpmnToAlgoModelConverterTest.java
@@ -1,12 +1,9 @@
 /*
  * Copyright 2020 Bonitasoft S.A.
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
  * http://www.apache.org/licenses/LICENSE-2.0
- *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,34 +14,43 @@ package io.process.analytics.tools.bpmn.generator.converter;
 
 import io.process.analytics.tools.bpmn.generator.internal.generated.model.TDefinitions;
 import io.process.analytics.tools.bpmn.generator.model.Diagram;
+import io.process.analytics.tools.bpmn.generator.model.Edge;
+import io.process.analytics.tools.bpmn.generator.model.Shape;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static io.process.analytics.tools.bpmn.generator.internal.SemanticTest.definitionsFromBpmnFile;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 class BpmnToAlgoModelConverterTest {
 
     @Test
     public void convertBpmnFlowNodesIntoDiagram() {
-//        <semantic:startEvent name="Start Event" id="startEvent_1">
-//            <semantic:outgoing>task_1</semantic:outgoing>
-//        </semantic:startEvent>
-//        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 1" id="task_1">
-//            <semantic:incoming>startEvent_1</semantic:incoming>
-//            <semantic:outgoing>endEvent_1</semantic:outgoing>
-//        </semantic:task>
-//        <semantic:endEvent name="End Event" id="endEvent_1">
-//            <semantic:incoming>task_1</semantic:incoming>
-//        </semantic:endEvent>
-//        <semantic:sequenceFlow sourceRef="startEvent_1" targetRef="task_1" name="" id="sequenceFlow_1"/>
-//        <semantic:sequenceFlow sourceRef="task_1" targetRef="endEvent_1" name="" id="sequenceFlow_2"/>
-        TDefinitions definitions = definitionsFromBpmnFile("src/test/resources/bpmn/02-startEvent_task_endEvent-without-collaboration.bpmn.xml");
+        //        <semantic:startEvent name="Start Event" id="startEvent_1">
+        //            <semantic:outgoing>task_1</semantic:outgoing>
+        //        </semantic:startEvent>
+        //        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 1" id="task_1">
+        //            <semantic:incoming>startEvent_1</semantic:incoming>
+        //            <semantic:outgoing>endEvent_1</semantic:outgoing>
+        //        </semantic:task>
+        //        <semantic:endEvent name="End Event" id="endEvent_1">
+        //            <semantic:incoming>task_1</semantic:incoming>
+        //        </semantic:endEvent>
+        //        <semantic:sequenceFlow sourceRef="startEvent_1" targetRef="task_1" name="" id="sequenceFlow_1"/>
+        //        <semantic:sequenceFlow sourceRef="task_1" targetRef="endEvent_1" name="" id="sequenceFlow_2"/>
+        TDefinitions definitions = definitionsFromBpmnFile(
+                "src/test/resources/bpmn/02-startEvent_task_endEvent-without-collaboration.bpmn.xml");
 
         Diagram diagram = new BpmnToAlgoModelConverter().toAlgoModel(definitions);
 
-        assertThat(diagram).isNull();
-//        assertThat(diagram.getShapes()).hasSize(2);
+        assertThat(diagram.getShapes()).containsOnly(
+                new Shape("startEvent_1", "Start Event"),
+                new Shape("task_1", "Task 1"),
+                new Shape("endEvent_1", "End Event"));
+        assertThat(diagram.getEdges()).containsOnly(
+                new Edge("startEvent_1", "task_1"),
+                new Edge("task_1", "endEvent_1"));
     }
 
 }

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/converter/BpmnToAlgoModelConverterTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/converter/BpmnToAlgoModelConverterTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.process.analytics.tools.bpmn.generator.converter;
+
+import io.process.analytics.tools.bpmn.generator.internal.generated.model.TDefinitions;
+import io.process.analytics.tools.bpmn.generator.model.Diagram;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+
+import static io.process.analytics.tools.bpmn.generator.internal.BpmnInOut.defaultBpmnInOut;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class BpmnToAlgoModelConverterTest {
+
+    @Test
+    public void convertBpmnFlowNodesIntoDiagram() {
+//        <semantic:startEvent name="Start Event" id="startEvent_1">
+//            <semantic:outgoing>task_1</semantic:outgoing>
+//        </semantic:startEvent>
+//        <semantic:task completionQuantity="1" isForCompensation="false" startQuantity="1" name="Task 1" id="task_1">
+//            <semantic:incoming>startEvent_1</semantic:incoming>
+//            <semantic:outgoing>endEvent_1</semantic:outgoing>
+//        </semantic:task>
+//        <semantic:endEvent name="End Event" id="endEvent_1">
+//            <semantic:incoming>task_1</semantic:incoming>
+//        </semantic:endEvent>
+//        <semantic:sequenceFlow sourceRef="startEvent_1" targetRef="task_1" name="" id="sequenceFlow_1"/>
+//        <semantic:sequenceFlow sourceRef="task_1" targetRef="endEvent_1" name="" id="sequenceFlow_2"/>
+        TDefinitions definitions = fromBpmnFile("src/test/resources/bpmn/02-startEvent_task_endEvent-without-collaboration.bpmn.xml");
+
+        Diagram diagram = new BpmnToAlgoModelConverter().toAlgoModel(definitions);
+
+        assertThat(diagram).isNull();
+//        assertThat(diagram.getShapes()).hasSize(2);
+    }
+
+
+    private static TDefinitions fromBpmnFile(String bpmnFilePath) {
+        return defaultBpmnInOut().readFromBpmn(new File(bpmnFilePath));
+    }
+
+}

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/internal/BPMNDiagramRichBuilderTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/internal/BPMNDiagramRichBuilderTest.java
@@ -15,10 +15,9 @@
  */
 package io.process.analytics.tools.bpmn.generator.internal;
 
-import static io.process.analytics.tools.bpmn.generator.internal.BpmnInOut.defaultBpmnInOut;
+import static io.process.analytics.tools.bpmn.generator.internal.SemanticTest.definitionsFromBpmnFile;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.File;
 import java.util.List;
 
 import javax.xml.namespace.QName;
@@ -88,10 +87,6 @@ class BPMNDiagramRichBuilderTest {
 
     private static BPMNDiagramRichBuilder newBuildFromBpmnFile(String bpmnFilePath) {
         return new BPMNDiagramRichBuilder(definitionsFromBpmnFile(bpmnFilePath));
-    }
-
-    private static TDefinitions definitionsFromBpmnFile(String bpmnFilePath) {
-        return defaultBpmnInOut().readFromBpmn(new File(bpmnFilePath));
     }
 
 }

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/internal/SemanticTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/internal/SemanticTest.java
@@ -1,12 +1,9 @@
 /*
  * Copyright 2020 Bonitasoft S.A.
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
  * http://www.apache.org/licenses/LICENSE-2.0
- *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,13 +14,12 @@ package io.process.analytics.tools.bpmn.generator.internal;
 
 import static io.process.analytics.tools.bpmn.generator.internal.BpmnInOut.defaultBpmnInOut;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 
 import java.io.File;
 
+import io.process.analytics.tools.bpmn.generator.internal.generated.model.*;
 import org.junit.jupiter.api.Test;
-
-import io.process.analytics.tools.bpmn.generator.internal.generated.model.TDefinitions;
-import io.process.analytics.tools.bpmn.generator.internal.generated.model.TProcess;
 
 public class SemanticTest {
 
@@ -37,7 +33,8 @@ public class SemanticTest {
 
     @Test
     public void detect_collaboration_when_not_exist_in_bpmn_file() {
-        Semantic semantic = semanticFromBpmnFile("src/test/resources/bpmn/02-startEvent_task_endEvent-without-collaboration.bpmn.xml");
+        Semantic semantic = semanticFromBpmnFile(
+                "src/test/resources/bpmn/02-startEvent_task_endEvent-without-collaboration.bpmn.xml");
         assertThat(semantic.getCollaboration()).isEmpty();
     }
 
@@ -51,14 +48,22 @@ public class SemanticTest {
 
     @Test
     public void detect_bpmn_elements_in_bpmn_file() {
-        Semantic semantic = semanticFromBpmnFile("src/test/resources/bpmn/01-startEvent.bpmn.xml");
+        Semantic semantic = semanticFromBpmnFile(
+                "src/test/resources/bpmn/02-startEvent_task_endEvent-without-collaboration.bpmn.xml");
         // we know that there is a process (see other tests)
         TProcess process = semantic.getProcesses().get(0);
 
-        semantic.getBpmnElements(process);
+        Semantic.BpmnElements bpmnElements = semantic.getBpmnElements(process);
 
-
-
+        assertThat(bpmnElements.getFlowNodes())
+                .extracting(Object::getClass, TFlowElement::getId)
+                .containsOnly(tuple(TStartEvent.class, "startEvent_1"),
+                        tuple(TTask.class, "task_1"),
+                        tuple(TEndEvent.class, "endEvent_1"));
+        assertThat(bpmnElements.getSequenceFlows())
+                .extracting(Object::getClass, TFlowElement::getId)
+                .containsOnly(tuple(TSequenceFlow.class, "sequenceFlow_1"),
+                        tuple(TSequenceFlow.class, "sequenceFlow_2"));
     }
 
     public static TDefinitions definitionsFromBpmnFile(String bpmnFilePath) {

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/internal/SemanticTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/internal/SemanticTest.java
@@ -49,6 +49,18 @@ class SemanticTest {
                 .extracting(TProcess::getId).containsExactly("Process_1duwsyj");
     }
 
+    @Test
+    public void detect_bpmn_elements_in_bpmn_file() {
+        Semantic semantic = semanticFromBpmnFile("src/test/resources/bpmn/01-startEvent.bpmn.xml");
+        // we know that there is a process (see other tests)
+        TProcess process = semantic.getProcesses().get(0);
+
+        semantic.getBpmnElements(process);
+
+
+
+    }
+
     private static Semantic semanticFromBpmnFile(String bpmnFilePath) {
         TDefinitions tDefinitions = defaultBpmnInOut().readFromBpmn(new File(bpmnFilePath));
         return new Semantic(tDefinitions);

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/internal/SemanticTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/internal/SemanticTest.java
@@ -25,7 +25,7 @@ import org.junit.jupiter.api.Test;
 import io.process.analytics.tools.bpmn.generator.internal.generated.model.TDefinitions;
 import io.process.analytics.tools.bpmn.generator.internal.generated.model.TProcess;
 
-class SemanticTest {
+public class SemanticTest {
 
     @Test
     public void detect_collaboration_when_exist_in_bpmn_file() {
@@ -61,9 +61,12 @@ class SemanticTest {
 
     }
 
+    public static TDefinitions definitionsFromBpmnFile(String bpmnFilePath) {
+        return defaultBpmnInOut().readFromBpmn(new File(bpmnFilePath));
+    }
+
     private static Semantic semanticFromBpmnFile(String bpmnFilePath) {
-        TDefinitions tDefinitions = defaultBpmnInOut().readFromBpmn(new File(bpmnFilePath));
-        return new Semantic(tDefinitions);
+        return new Semantic(definitionsFromBpmnFile(bpmnFilePath));
     }
 
 }


### PR DESCRIPTION
**Depends on #22**:  to get the AsciiExporter

This PR let you load a BPMN file, pass data through the algorithm and export the result to an ASCII or SVG file.
The BPMN output export will be manage in another PR as it requires extra conversion from internal model to BPMN.

Notice that this is the initial support for BPMN load, there is no management of lane or laneset. This should only work with process without such elements.

Here is the SVG render when loading the [A.2.0.bpmn file from BPMN-MIWG](https://github.com/bpmn-miwg/bpmn-miwg-test-suite/blob/master/Reference/A.2.0.bpmn)

BPMN render | SVG export
------------ | -------------
[<img src="https://raw.githubusercontent.com/bpmn-miwg/bpmn-miwg-test-suite/master/Reference/A.2.0.png" width="300"/>](https://github.com/bpmn-miwg/bpmn-miwg-test-suite/blob/master/Reference/A.2.0.bpmn) |[<img src="https://user-images.githubusercontent.com/27200110/80796578-dc482d00-8b9f-11ea-964f-66ee039c65d7.png" width="300"/>](https://github.com/bpmn-miwg/bpmn-miwg-test-suite/blob/master/Reference/A.2.0.bpmn)


Covers #13 