### PR TITLE
handle positions of elements after a split

### DIFF
--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/algo/ShapeLayouter.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/algo/ShapeLayouter.java
@@ -16,29 +16,64 @@ public class ShapeLayouter {
 
     public Grid layout(SortedDiagram diagram) {
         Grid grid = new Grid();
+        for (int i = 0; i < diagram.getShapes().size(); i++) {
+
+        }
         for (Shape shape : diagram.getShapes()) {
+            Position positionOfCurrentShape;
             List<Edge> incomingEdges = diagram.getIncomingEdges(shape.getId());
             if (incomingEdges.isEmpty()) {
                 //This is a start node, insert it in a new column
-                grid.add(position(shape, 0, grid.getLastColumnIndex() + 1));
+                positionOfCurrentShape = addStartShape(grid, shape);
             } else if (incomingEdges.size() == 1) {
                 //find the previous node position
                 String previousShapeID = incomingEdges.get(0).getFrom();
                 List<Edge> outgoingEdgesOfPreviousShape = diagram.getOutgoingEdges(previousShapeID);
                 if (outgoingEdgesOfPreviousShape.size() == 1) {
-                    addDirectlyNextTo(grid, shape, previousShapeID);
+                    positionOfCurrentShape = addDirectlyNextTo(grid, shape, previousShapeID);
                 } else {
-                    //next to a split
-                    throw new UnsupportedOperationException("Positioning a Node that is splitting is not yet supported");
+                    positionOfCurrentShape = addSplit(grid, shape, previousShapeID, outgoingEdgesOfPreviousShape);
                 }
             } else {
-                addJoin(grid, shape, incomingEdges);
+                positionOfCurrentShape = addJoin(grid, shape, incomingEdges);
+            }
+            List<Edge> outgoingEdges = diagram.getOutgoingEdges(shape.getId());
+            if (outgoingEdges.size() > 1) {
+                //add rows to place elements of this split
+                int rowsToAddBeforeAndAfter = outgoingEdges.size() / 2;
+                for (int i = 0; i < rowsToAddBeforeAndAfter; i++) {
+                    grid.addRowAfter(positionOfCurrentShape.getY());
+                    grid.addRowBefore(positionOfCurrentShape.getY());
+                }
             }
         }
         return grid;
     }
 
-    private void addJoin(Grid grid, Shape shape, List<Edge> incomingEdges) {
+    private Position addStartShape(Grid grid, Shape shape) {
+        Position position = position(shape, 0, grid.getLastColumnIndex() + 1);
+        grid.add(position);
+        return position;
+    }
+
+    private Position addSplit(Grid grid, Shape shape, String previousShapeID, List<Edge> outgoingEdgesOfPreviousShape) {
+        Position previousShapePosition = grid.getPosition(previousShapeID);
+        int numberOfShapesInTheSplit = outgoingEdgesOfPreviousShape.size();
+        int indexOfCurrentShape = outgoingEdgesOfPreviousShape.stream().map(Edge::getTo).collect(Collectors.toList()).indexOf(shape.getId());
+        //put element right to the split vertically distributed according to the index
+        int relativeYPosition;
+        if (numberOfShapesInTheSplit % 2 == 0 && indexOfCurrentShape >= numberOfShapesInTheSplit / 2) {
+            //if there is an even number of element, there is no "middle" element so we must add 1 to the index of the elements after the "middle"
+            relativeYPosition = indexOfCurrentShape + 1 - numberOfShapesInTheSplit / 2;
+        } else {
+            relativeYPosition = indexOfCurrentShape - numberOfShapesInTheSplit / 2;
+        }
+        Position position = position(shape, previousShapePosition.getX() + 1, previousShapePosition.getY() + relativeYPosition);
+        grid.add(position);
+        return position;
+    }
+
+    private Position addJoin(Grid grid, Shape shape, List<Edge> incomingEdges) {
         //first implementation: middle of elements it joins
         // later we should also try yo find the split to align it to that if possible
         List<Position> positions = incomingEdges.stream().map(Edge::getFrom).map(grid::getPosition).collect(Collectors.toList());
@@ -52,12 +87,16 @@ public class ShapeLayouter {
             grid.addRowAfter(yElement);
             yElement++;
         }
-        grid.add(position(shape, xElement, yElement));
+        Position position = position(shape, xElement, yElement);
+        grid.add(position);
+        return position;
     }
 
-    private void addDirectlyNextTo(Grid grid, Shape shapeToAdd, String rightTo) {
+    private Position addDirectlyNextTo(Grid grid, Shape shapeToAdd, String rightTo) {
         Position previous = grid.getPosition(rightTo);
-        grid.add(position(shapeToAdd, previous.getX() + 1, previous.getY()));
+        Position position = position(shapeToAdd, previous.getX() + 1, previous.getY());
+        grid.add(position);
+        return position;
     }
 
 

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/algo/ShapeLayouter.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/algo/ShapeLayouter.java
@@ -16,9 +16,6 @@ public class ShapeLayouter {
 
     public Grid layout(SortedDiagram diagram) {
         Grid grid = new Grid();
-        for (int i = 0; i < diagram.getShapes().size(); i++) {
-
-        }
         for (Shape shape : diagram.getShapes()) {
             Position positionOfCurrentShape;
             List<Edge> incomingEdges = diagram.getIncomingEdges(shape.getId());

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/export/ASCIIExporter.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/export/ASCIIExporter.java
@@ -1,0 +1,56 @@
+package io.process.analytics.tools.bpmn.generator.export;
+
+import java.util.Arrays;
+import java.util.List;
+
+import io.process.analytics.tools.bpmn.generator.model.Grid;
+import io.process.analytics.tools.bpmn.generator.model.Position;
+
+public class ASCIIExporter {
+
+    private static final int CELL_WIDTH = 7;
+
+    public String export(Grid grid) {
+        int width = grid.width();
+        int height = grid.height();
+        List<Position> positions = grid.getPositions();
+        return export(width, height, positions);
+    }
+
+    public String export(int width, int height, List<Position> positions) {
+        char[][] charGrid = new char[height][width * CELL_WIDTH];
+        for (char[] chars : charGrid) {
+            Arrays.fill(chars, ' ');
+        }
+        for (Position position : positions) {
+            char[] charRow = charGrid[position.getY()];
+            char[] name = position.getShapeName().toCharArray();
+            System.arraycopy(name, 0, charRow, 7 * position.getX(), Math.min(name.length, CELL_WIDTH));
+        }
+        StringBuilder content = new StringBuilder("Diagram:\n");
+        content.append('+').append(horizontalBar(CELL_WIDTH * width)).append('+').append('\n');
+        for (char[] chars : charGrid) {
+            content.append('|').append(chars).append('|').append('\n');
+        }
+        content.append('+').append(horizontalBar(CELL_WIDTH * width)).append('+').append('\n');
+        return content.toString();
+    }
+
+
+    private char[] horizontalBar(int size) {
+        char[] chars = new char[size];
+        Arrays.fill(chars, '-');
+        return chars;
+    }
+
+    public static String toAscii(Grid grid) {
+        return new ASCIIExporter().export(grid);
+    }
+
+    public static String toAscii(int width, int height, List<Position> positions) {
+        return new ASCIIExporter().export(width, height, positions);
+    }
+    public static String toAscii(int width, int height, Position... positions) {
+        return toAscii(width, height, Arrays.asList(positions));
+    }
+}

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/model/Grid.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/model/Grid.java
@@ -68,4 +68,8 @@ public class Grid {
             positions.add(cellToMove.toBuilder().y(cellToMove.getY() + 1).build());
         }
     }
+
+    public void addRowBefore(int y) {
+        addRowAfter(y - 1);
+    }
 }

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/model/Position.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/model/Position.java
@@ -7,10 +7,11 @@ import lombok.Data;
 @Builder(toBuilder = true)
 public class Position {
     private final String shape;
+    private final String shapeName;
     private final int x;
     private final int y;
 
     public static Position position(Shape shape, int x, int y) {
-        return new Position(shape.getId(), x, y);
+        return new Position(shape.getId(), shape.getName(), x, y);
     }
 }

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/algo/ShapeLayouterTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/algo/ShapeLayouterTest.java
@@ -13,8 +13,7 @@ import org.junit.jupiter.api.Test;
 
 class ShapeLayouterTest {
 
-
-    private ShapeLayouter shapeLayouter = new ShapeLayouter();
+    private final ShapeLayouter shapeLayouter = new ShapeLayouter();
 
     Shape start = shape("start");
     Shape step1 = shape("step1");
@@ -62,6 +61,11 @@ class ShapeLayouterTest {
 
     @Test
     public void should_layout_a_diagram_that_have_2_branches() {
+        //  +---------------------------------+
+        //  |              step2              |
+        //  |start  step1         step4  end  |
+        //  |              step3              |
+        //  +---------------------------------+
         SortedDiagram diagram = SortedDiagram.builder()
                 .shape(start)
                 .shape(step1)
@@ -92,6 +96,11 @@ class ShapeLayouterTest {
 
     @Test
     public void should_layout_a_diagram_that_have_join() {
+        //  +--------------+
+        //  |step1         |
+        //  |       step3  |
+        //  |step2         |
+        //  +--------------+
         SortedDiagram diagram = SortedDiagram.builder()
                 .shape(step1)
                 .shape(step2)
@@ -111,6 +120,11 @@ class ShapeLayouterTest {
 
     @Test
     public void should_layout_a_diagram_with_a_split_of_2_elements() {
+        //  +--------------+
+        //  |       step2  |
+        //  |step1         |
+        //  |       step3  |
+        //  +--------------+
         SortedDiagram diagram = SortedDiagram.builder()
                 .shape(step1)
                 .shape(step2)
@@ -130,6 +144,11 @@ class ShapeLayouterTest {
 
     @Test
     public void should_layout_a_diagram_with_a_split_of_3_elements() {
+        //  +--------------+
+        //  |       step2  |
+        //  |step1  step3  |
+        //  |       step4  |
+        //  +--------------+
         SortedDiagram diagram = SortedDiagram.builder()
                 .shape(step1)
                 .shape(step2)
@@ -153,6 +172,11 @@ class ShapeLayouterTest {
 
     @Test
     public void should_layout_a_diagram_that_have_join_with_element_not_in_the_same_column() {
+        //  +---------------------+
+        //  |step1  step2         |
+        //  |              step3  |
+        //  |step4                |
+        //  +---------------------+
         SortedDiagram diagram = SortedDiagram.builder()
                 .shape(step1)
                 .shape(step2)
@@ -175,6 +199,11 @@ class ShapeLayouterTest {
 
     @Test
     public void should_layout_a_diagram_that_have_join_three_element() {
+        // +--------------+
+        // |step1         |
+        // |step2  step4  |
+        // |step3         |
+        // +--------------+
         SortedDiagram diagram = SortedDiagram.builder()
                 .shape(step1)
                 .shape(step2)
@@ -197,6 +226,12 @@ class ShapeLayouterTest {
 
     @Test
     public void should_layout_a_diagram_that_have_join_only_two_elements_of_three() {
+        //  +--------------+
+        //  |step1         |
+        //  |step2         |
+        //  |       step4  |
+        //  |step3         |
+        //  +--------------+
         SortedDiagram diagram = SortedDiagram.builder()
                 .shape(step1)
                 .shape(step2)

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/algo/ShapeLayouterTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/algo/ShapeLayouterTest.java
@@ -1,5 +1,6 @@
 package io.process.analytics.tools.bpmn.generator.algo;
 
+import static io.process.analytics.tools.bpmn.generator.export.ASCIIExporter.toAscii;
 import static io.process.analytics.tools.bpmn.generator.model.Edge.edge;
 import static io.process.analytics.tools.bpmn.generator.model.Position.position;
 import static io.process.analytics.tools.bpmn.generator.model.Shape.shape;
@@ -8,7 +9,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import io.process.analytics.tools.bpmn.generator.model.Grid;
 import io.process.analytics.tools.bpmn.generator.model.Shape;
 import io.process.analytics.tools.bpmn.generator.model.SortedDiagram;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 class ShapeLayouterTest {
@@ -45,9 +45,7 @@ class ShapeLayouterTest {
 
         Grid grid = shapeLayouter.layout(diagram);
 
-        assertThat(grid.width()).isEqualTo(2);
-        assertThat(grid.height()).isEqualTo(1);
-        assertThat(grid.getPositions()).containsExactly(position(step1, 0, 0), position(step2, 1, 0));
+        assertThat(toAscii(grid)).isEqualTo(toAscii(2, 1, position(step1, 0, 0), position(step2, 1, 0)));
     }
 
     @Test
@@ -59,13 +57,10 @@ class ShapeLayouterTest {
 
         Grid grid = shapeLayouter.layout(diagram);
 
-        assertThat(grid.width()).isEqualTo(1);
-        assertThat(grid.height()).isEqualTo(2);
-        assertThat(grid.getPositions()).containsExactly(position(step1, 0, 0), position(step2, 0, 1));
+        assertThat(toAscii(grid)).isEqualTo(toAscii(1, 2, position(step1, 0, 0), position(step2, 0, 1)));
     }
 
     @Test
-    @Disabled("Not yet implemented")
     public void should_layout_a_diagram_that_have_2_branches() {
         SortedDiagram diagram = SortedDiagram.builder()
                 .shape(start)
@@ -85,8 +80,14 @@ class ShapeLayouterTest {
 
         Grid grid = shapeLayouter.layout(diagram);
 
-        assertThat(grid.getPositions()).isNull();
-
+        assertThat(toAscii(grid)).isEqualTo(toAscii(5, 3,
+                position(start, 0, 1),
+                position(step1, 1, 1),
+                position(step2, 2, 0),
+                position(step3, 2, 2),
+                position(step4, 3, 1),
+                position(end, 4, 1)
+        ));
     }
 
     @Test
@@ -106,6 +107,48 @@ class ShapeLayouterTest {
                 position(step1, 0, 0),
                 position(step2, 0, 2),
                 position(step3, 1, 1));
+    }
+
+    @Test
+    public void should_layout_a_diagram_with_a_split_of_2_elements() {
+        SortedDiagram diagram = SortedDiagram.builder()
+                .shape(step1)
+                .shape(step2)
+                .shape(step3)
+                .edge(edge(step1, step2))
+                .edge(edge(step1, step3))
+                .build();
+
+
+        Grid grid = shapeLayouter.layout(diagram);
+
+        assertThat(grid.getPositions()).as(toAscii(grid)).containsOnly(
+                position(step1, 0, 1),
+                position(step2, 1, 0),
+                position(step3, 1, 2));
+    }
+
+    @Test
+    public void should_layout_a_diagram_with_a_split_of_3_elements() {
+        SortedDiagram diagram = SortedDiagram.builder()
+                .shape(step1)
+                .shape(step2)
+                .shape(step3)
+                .shape(step4)
+                .edge(edge(step1, step2))
+                .edge(edge(step1, step3))
+                .edge(edge(step1, step4))
+                .build();
+
+
+        Grid grid = shapeLayouter.layout(diagram);
+
+
+        assertThat(toAscii(grid)).isEqualTo(toAscii(2, 3,
+                position(step1, 0, 1),
+                position(step2, 1, 0),
+                position(step3, 1, 1),
+                position(step4, 1, 2)));
     }
 
     @Test

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/model/GridTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/model/GridTest.java
@@ -13,7 +13,7 @@ class GridTest {
     private Shape nodeC = Shape.shape("c");
 
     @Test
-    public void should_move_element_when_adding_row() {
+    public void should_move_element_when_adding_row_after() {
         grid.add(position(nodeA, 0, 0));
         grid.add(position(nodeB, 0, 1));
         grid.add(position(nodeC, 0, 2));
@@ -24,6 +24,21 @@ class GridTest {
         assertThat(grid.getPositions()).containsExactly(
                 position(nodeA, 0, 0),
                 position(nodeB, 0, 1),
+                position(nodeC, 0, 3)
+        );
+    }
+    @Test
+    public void should_move_element_when_adding_row_before() {
+        grid.add(position(nodeA, 0, 0));
+        grid.add(position(nodeB, 0, 1));
+        grid.add(position(nodeC, 0, 2));
+
+
+        grid.addRowBefore(1);
+
+        assertThat(grid.getPositions()).containsExactly(
+                position(nodeA, 0, 0),
+                position(nodeB, 0, 2),
                 position(nodeC, 0, 3)
         );
     }


### PR DESCRIPTION
To do that, add rows above and below the element that have multiple
outgoing transition and then put each of the next element right of the
it.

Still not handled:
* Elements that split + join
* Overlapping of successive branches
* Joins should be align to its split element

Added in this PR a ASCII exported to have a visual feedback when
assertions are failing (try to change an assert in ShapeLayouterTest)

Closes #9