### PR TITLE
chore(travis): build on jdk8 and jdk11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ branches:
     - master
 
 install: skip
-script: cd java; ./mvnw verify
+script: cd java; ./mvnw -V verify

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: java
-jdk: openjdk8
 os: linux
 dist: xenial
+jdk:
+  - openjdk8
+  - openjdk11
 
 cache:
   directories:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# bpmn-layout-generators
+# bpmn-layout-generators [![Build Status](https://travis-ci.com/process-analytics/bpmn-layout-generators.svg?branch=master)](https://travis-ci.com/process-analytics/bpmn-layout-generators)
 
 Tools for generating missing BPMNDiagram elements in BPMN files
 

--- a/java/README.md
+++ b/java/README.md
@@ -2,12 +2,11 @@
 
 ## Requirements
 
-> JDK 8 (may work with higher versions, but this is not tested)
->
+> JDK 8 or JDK 11
 
 ## Build
 
-The project bundle a Maven Wrapper, so just run
+The project bundles a Maven Wrapper, so just run
 ``` bash
 ./mvnw package
 ```


### PR DESCRIPTION
This will ensure that even if we mainly target jdk8, the project also works with
jdk11