### PR TITLE
feat(render): adjust exported gateways and events shape and size

### DIFF
--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/converter/AlgoToDisplayModelConverter.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/converter/AlgoToDisplayModelConverter.java
@@ -59,6 +59,7 @@ public class AlgoToDisplayModelConverter {
             model.flowNode(DisplayFlowNode.builder().bpmnElementId(shape.getId())
                     .dimension(flowNodeDimension)
                     .label(label)
+                    .type(shape.getType())
                     .rx(y(10)).strokeWidth(y(5)).build());
         }
 
@@ -97,6 +98,7 @@ public class AlgoToDisplayModelConverter {
         public final DisplayDimension dimension;
         public final DisplayLabel label;
         // for non BPMN exporters only
+        public final ShapeType type;
         public final int rx;
         public final int strokeWidth;
 

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/converter/AlgoToDisplayModelConverter.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/converter/AlgoToDisplayModelConverter.java
@@ -59,10 +59,14 @@ public class AlgoToDisplayModelConverter {
             int y = yOffset + (CELL_HEIGHT - nodeHeight) / 2;
             DisplayDimension flowNodeDimension = new DisplayDimension(x, y, nodeWidth, nodeHeight);
 
-            // TODO adjust label coordinates depending on the shape type
-            //  this works well for activities, but no for events or gateways (here, the label is centered on the shape)
             int labelX = xOffset + x(50);
             int labelY = yOffset + y(50);
+            if (shapeType == ShapeType.EVENT) { // put the label under the shape
+                labelY = (int) (y + nodeHeight * 1.5);
+            } else if (shapeType == ShapeType.GATEWAY) { // put the label on the top left of the shape
+                labelX = (int) (x - nodeWidth * 0.5);
+                labelY = (int) (y - nodeHeight * 0.5);
+            }
 
             DisplayDimension labelDimension = new DisplayDimension(labelX, labelY, nodeWidth, nodeHeight);
             DisplayLabel label = new DisplayLabel(name, y(16), labelDimension);

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/converter/AlgoToDisplayModelConverter.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/converter/AlgoToDisplayModelConverter.java
@@ -35,19 +35,30 @@ public class AlgoToDisplayModelConverter {
         for (Position position : grid.getPositions()) {
             int xOffset = position.getX() * CELL_WIDTH;
             int yOffset = position.getY() * CELL_HEIGHT;
-            // TODO adjust node dimensions depending on the shape type
-            // this works well for activities, but no for events or gateways. For same, we need width=height
-            // and for event a smaller circle, probably also for gateways
             int nodeWidth = x(60);
             int nodeHeight = y(60);
+
+            // TODO manage when not found (should not occur)
+            Shape shape = diagram.getShapes().stream()
+                    .filter(s -> s.getId().equals(position.getShape()))
+                    .findFirst().get();
+            String name = shape.getName();
+
+            // ensure to have a square shape (i.e. same width and height) for non activity elements
+            ShapeType shapeType = shape.getType();
+            if (shapeType == ShapeType.EVENT || shapeType == ShapeType.GATEWAY) {
+                int nodeDimension = Math.min(nodeWidth, nodeHeight);
+                if (shapeType == ShapeType.EVENT) {
+                    nodeDimension /= 2;
+                }
+                nodeWidth = nodeDimension;
+                nodeHeight = nodeDimension;
+            }
 
             int x = xOffset + (CELL_WIDTH - nodeWidth) / 2;
             int y = yOffset + (CELL_HEIGHT - nodeHeight) / 2;
             DisplayDimension flowNodeDimension = new DisplayDimension(x, y, nodeWidth, nodeHeight);
 
-            // TODO manage when not found (should not occur)
-            Shape shape = diagram.getShapes().stream().filter(s -> s.getId().equals(position.getShape())).findFirst().get();
-            String name = shape.getName();
             // TODO adjust label coordinates depending on the shape type
             //  this works well for activities, but no for events or gateways (here, the label is centered on the shape)
             int labelX = xOffset + x(50);
@@ -59,7 +70,7 @@ public class AlgoToDisplayModelConverter {
             model.flowNode(DisplayFlowNode.builder().bpmnElementId(shape.getId())
                     .dimension(flowNodeDimension)
                     .label(label)
-                    .type(shape.getType())
+                    .type(shapeType)
                     .rx(y(10)).strokeWidth(y(5)).build());
         }
 

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/converter/BpmnToAlgoModelConverter.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/converter/BpmnToAlgoModelConverter.java
@@ -18,8 +18,9 @@ package io.process.analytics.tools.bpmn.generator.converter;
 import io.process.analytics.tools.bpmn.generator.internal.Semantic;
 import io.process.analytics.tools.bpmn.generator.internal.generated.model.*;
 import io.process.analytics.tools.bpmn.generator.model.Edge;
-import io.process.analytics.tools.bpmn.generator.model.Shape;
 import io.process.analytics.tools.bpmn.generator.model.Diagram;
+import io.process.analytics.tools.bpmn.generator.model.Shape;
+import io.process.analytics.tools.bpmn.generator.model.ShapeType;
 
 import java.util.List;
 
@@ -34,7 +35,7 @@ public class BpmnToAlgoModelConverter {
             Semantic.BpmnElements bpmnElements = semantic.getBpmnElements(process);
 
             bpmnElements.getFlowNodes().stream()
-                    .map(flowNode -> new Shape(flowNode.getId(), flowNode.getName()))
+                    .map(BpmnToAlgoModelConverter::toShape)
                     .forEach(diagram::shape);
 
             bpmnElements.getSequenceFlows().stream()
@@ -43,6 +44,11 @@ public class BpmnToAlgoModelConverter {
         }
 
         return diagram.build();
+    }
+
+    private static Shape toShape(TFlowElement flowNode) {
+        // TODO manage shape type
+        return new Shape(flowNode.getId(), flowNode.getName(), ShapeType.ACTIVITY);
     }
 
     // assuming this is a TBaseElement

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/converter/BpmnToAlgoModelConverter.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/converter/BpmnToAlgoModelConverter.java
@@ -15,14 +15,16 @@
  */
 package io.process.analytics.tools.bpmn.generator.converter;
 
+import static io.process.analytics.tools.bpmn.generator.model.ShapeType.*;
+
+import java.util.List;
+
 import io.process.analytics.tools.bpmn.generator.internal.Semantic;
 import io.process.analytics.tools.bpmn.generator.internal.generated.model.*;
 import io.process.analytics.tools.bpmn.generator.model.Edge;
 import io.process.analytics.tools.bpmn.generator.model.Diagram;
 import io.process.analytics.tools.bpmn.generator.model.Shape;
 import io.process.analytics.tools.bpmn.generator.model.ShapeType;
-
-import java.util.List;
 
 public class BpmnToAlgoModelConverter {
 
@@ -46,9 +48,15 @@ public class BpmnToAlgoModelConverter {
         return diagram.build();
     }
 
-    private static Shape toShape(TFlowElement flowNode) {
-        // TODO manage shape type
-        return new Shape(flowNode.getId(), flowNode.getName(), ShapeType.ACTIVITY);
+    // visible for testing
+    static Shape toShape(TFlowElement flowNode) {
+        ShapeType shapeType = ACTIVITY;
+        if (flowNode instanceof TGateway) {
+            shapeType = GATEWAY;
+        } else if (flowNode instanceof TEvent) {
+            shapeType = EVENT;
+        }
+        return new Shape(flowNode.getId(), flowNode.getName(), shapeType);
     }
 
     // assuming this is a TBaseElement

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/export/SVGExporter.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/export/SVGExporter.java
@@ -67,7 +67,9 @@ public class SVGExporter {
                         .append(" stroke=\"").append(colorActivityStroke).append("\"")
                         .append(" stroke-width=\"").append(strokeWidth).append("\"")
                         .append(" />\n");
-            } else if (flowNode.type == ShapeType.EVENT) {
+            }
+            // draw circle (with an eclipse because we like complicated things!)
+            else if (flowNode.type == ShapeType.EVENT) {
                 log.debug("Exporting event {}", flowNode.bpmnElementId);
                 int rx = flowNodeDimension.width / 2;
                 int ry = flowNodeDimension.height / 2;
@@ -83,18 +85,30 @@ public class SVGExporter {
                         .append(" stroke-width=\"").append(strokeWidth).append("\"")
                         .append(" pointer-events=\"all\"")
                         .append(" />\n");
-            } else if (flowNode.type == ShapeType.GATEWAY) {
+            }
+            // draw rhombus/diamond
+            else if (flowNode.type == ShapeType.GATEWAY) {
                 log.debug("Exporting gateway {}", flowNode.bpmnElementId);
-                // TODO gateway should be a rhombus/diamond instead of a rectangle
-                content.append("<rect")
-                        .append(" x=\"").append(flowNodeDimension.x).append("\"")
-                        .append(" y=\"").append(flowNodeDimension.y).append("\"")
-                        .append(" width=\"").append(flowNodeDimension.width).append("\"")
-                        .append(" height=\"").append(flowNodeDimension.height).append("\"")
-                        .append(" rx=\"").append(flowNode.rx).append("\"")
-                        .append(" fill=\"").append(colorGatewayFill).append("\"")
-                        .append(" stroke=\"").append(colorGatewayStroke).append("\"")
-                        .append(" stroke-width=\"").append(strokeWidth).append("\"")
+                int x = flowNodeDimension.x;
+                int y = flowNodeDimension.y;
+                int width = flowNodeDimension.width;
+                int height = flowNodeDimension.height;
+
+                int midWidth = width / 2;
+                int midHeight = height / 2;
+
+                content.append("<polygon")
+                        .append(" points=\"")
+                        .append(x + midWidth).append(",").append(y)
+                        .append(" ").append(x + width).append(",").append(y + midHeight)
+                        .append(" ").append(x + midWidth).append(",").append(y + height)
+                        .append(" ").append(x).append(",").append(y + midHeight)
+                        .append("\"")
+                        .append(" style=\"")
+                        .append("fill:").append(colorGatewayFill)
+                        .append(";stroke:").append(colorGatewayStroke)
+                        .append(";stroke-width:").append(strokeWidth)
+                        .append("\"")
                         .append(" />\n");
             }
 

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/export/SVGExporter.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/export/SVGExporter.java
@@ -68,7 +68,7 @@ public class SVGExporter {
                         .append(" stroke-width=\"").append(strokeWidth).append("\"")
                         .append(" />\n");
             }
-            // draw circle (with an eclipse because we like complicated things!)
+            // draw circle (with an eclipse to eventually detect if shape is not squared)
             else if (flowNode.type == ShapeType.EVENT) {
                 log.debug("Exporting event {}", flowNode.bpmnElementId);
                 int rx = flowNodeDimension.width / 2;
@@ -112,12 +112,15 @@ public class SVGExporter {
                         .append(" />\n");
             }
 
+
+            // TODO fill color depends on the shape type
+            // TODO seems not used to render the svg
+            String labelFillColor = "#374962"; // fill color for activities
             content.append("<text")
                     .append(" x=\"").append(labelDimension.x).append("\"")
                     .append(" y=\"").append(labelDimension.y).append("\"")
                     .append(" text-anchor=\"middle\" font-size=\"").append(label.fontSize).append("\"")
-                    // TODO extract color
-                    .append(" fill=\"#374962\">")
+                    .append(" fill=\"").append(labelFillColor).append("\">")
                     .append(label.text)
                     .append("</text>\n");
         }

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/export/SVGExporter.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/export/SVGExporter.java
@@ -41,8 +41,12 @@ public class SVGExporter {
                 .append(model.height).append("\">\n");
 
         // TODO extract colors to constant or configurable field
-        final String colorFillGateway ="gold";
-        final String colorStrokeGateway ="GoldenRod";
+        final String colorActivityFill ="#E3E3E3";
+        final String colorActivityStroke ="#92ADC8";
+        final String colorEventFill ="LightSalmon";
+        final String colorEventStroke ="FireBrick";
+        final String colorGatewayFill ="Gold";
+        final String colorGatewayStroke ="GoldenRod";
 
         for (DisplayFlowNode flowNode : model.flowNodes) {
             DisplayDimension flowNodeDimension = flowNode.dimension;
@@ -53,15 +57,16 @@ public class SVGExporter {
 
             if (flowNode.type == ShapeType.ACTIVITY) {
                 log.debug("Exporting activity {}", flowNode.bpmnElementId);
-                content.append("<rect ");
-                content.append("x=\"").append(flowNodeDimension.x).append("\" ");
-                content.append("y=\"").append(flowNodeDimension.y).append("\" ");
-                content.append("width=\"").append(flowNodeDimension.width).append("\" ");
-                content.append("height=\"").append(flowNodeDimension.height).append("\" ");
-                content.append("rx=\"").append(flowNode.rx).append("\" ");
-                // TODO extract colors
-                content.append("fill=\"#E3E3E3\" stroke=\"#92ADC8\" ");
-                content.append("stroke-width=\"").append(strokeWidth).append("\"/>\n");
+                content.append("<rect")
+                        .append(" x=\"").append(flowNodeDimension.x).append("\"")
+                        .append(" y=\"").append(flowNodeDimension.y).append("\"")
+                        .append(" width=\"").append(flowNodeDimension.width).append("\"")
+                        .append(" height=\"").append(flowNodeDimension.height).append("\"")
+                        .append(" rx=\"").append(flowNode.rx).append("\"")
+                        .append(" fill=\"").append(colorActivityFill).append("\"")
+                        .append(" stroke=\"").append(colorActivityStroke).append("\"")
+                        .append(" stroke-width=\"").append(strokeWidth).append("\"")
+                        .append(" />\n");
             } else if (flowNode.type == ShapeType.EVENT) {
                 log.debug("Exporting event {}", flowNode.bpmnElementId);
                 // TODO improve cx/cy management
@@ -72,35 +77,34 @@ public class SVGExporter {
                         .append(" cy=\"").append(flowNodeDimension.y).append("\"")
                         .append(" rx=\"").append(flowNodeDimension.width).append("\"")
                         .append(" ry=\"").append(flowNodeDimension.height).append("\"")
-                        // TODO extract colors
-                        .append(" fill=\"white\" stroke=\"black\"")
+                        .append(" fill=\"").append(colorEventFill).append("\"")
+                        .append(" stroke=\"").append(colorEventStroke).append("\"")
                         .append(" stroke-width=\"").append(strokeWidth).append("\"")
                         .append(" pointer-events=\"all\"")
-                        .append(" />\n")
-                //
-                ;
+                        .append(" />\n");
             } else if (flowNode.type == ShapeType.GATEWAY) {
                 log.debug("Exporting gateway {}", flowNode.bpmnElementId);
                 // TODO gateway should be a rhombus/diamond instead of a rectangle
-                content.append("<rect");
-                content.append(" x=\"").append(flowNodeDimension.x).append("\"");
-                content.append(" y=\"").append(flowNodeDimension.y).append("\"");
-                content.append(" width=\"").append(flowNodeDimension.width).append("\"");
-                content.append(" height=\"").append(flowNodeDimension.height).append("\"");
-                content.append(" rx=\"").append(flowNode.rx).append("\"");
-                content.append(" fill=\"").append(colorFillGateway).append("\"")
-                        .append(" stroke=\"").append(colorStrokeGateway).append("\"")
+                content.append("<rect")
+                        .append(" x=\"").append(flowNodeDimension.x).append("\"")
+                        .append(" y=\"").append(flowNodeDimension.y).append("\"")
+                        .append(" width=\"").append(flowNodeDimension.width).append("\"")
+                        .append(" height=\"").append(flowNodeDimension.height).append("\"")
+                        .append(" rx=\"").append(flowNode.rx).append("\"")
+                        .append(" fill=\"").append(colorGatewayFill).append("\"")
+                        .append(" stroke=\"").append(colorGatewayStroke).append("\"")
                         .append(" stroke-width=\"").append(strokeWidth).append("\"")
-                        .append(" />\n")
-                //
-                ;
+                        .append(" />\n");
             }
 
-            content.append("<text x=\"").append(labelDimension.x);
-            content.append("\" y=\"").append(labelDimension.y);
-            content.append("\" text-anchor=\"middle\" font-size=\"").append(label.fontSize);
-            content.append("\" fill=\"#374962\">");
-            content.append(label.text).append("</text>\n");
+            content.append("<text")
+                    .append(" x=\"").append(labelDimension.x).append("\"")
+                    .append(" y=\"").append(labelDimension.y).append("\"")
+                    .append(" text-anchor=\"middle\" font-size=\"").append(label.fontSize).append("\"")
+                    // TODO extract color
+                    .append(" fill=\"#374962\">")
+                    .append(label.text)
+                    .append("</text>\n");
         }
         content.append("</svg>");
         return content.toString().getBytes();

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/export/SVGExporter.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/export/SVGExporter.java
@@ -69,14 +69,15 @@ public class SVGExporter {
                         .append(" />\n");
             } else if (flowNode.type == ShapeType.EVENT) {
                 log.debug("Exporting event {}", flowNode.bpmnElementId);
-                // TODO improve cx/cy management
-                //<ellipse cx="201" cy="291" rx="15" ry="15" fill="white" stroke="black" stroke-width="2" pointer-events="all"></ellipse>
-                //                  <ellipse cx="752" cy="260" rx="16" ry="16" fill="white" stroke="black" stroke-width="5" pointer-events="all"></ellipse>
+                int rx = flowNodeDimension.width / 2;
+                int ry = flowNodeDimension.height / 2;
+                int cx = flowNodeDimension.x + rx;
+                int cy = flowNodeDimension.y + ry;
                 content.append("<ellipse")
-                        .append(" cx=\"").append(flowNodeDimension.x).append("\"")
-                        .append(" cy=\"").append(flowNodeDimension.y).append("\"")
-                        .append(" rx=\"").append(flowNodeDimension.width).append("\"")
-                        .append(" ry=\"").append(flowNodeDimension.height).append("\"")
+                        .append(" cx=\"").append(cx).append("\"")
+                        .append(" cy=\"").append(cy).append("\"")
+                        .append(" rx=\"").append(rx).append("\"")
+                        .append(" ry=\"").append(ry).append("\"")
                         .append(" fill=\"").append(colorEventFill).append("\"")
                         .append(" stroke=\"").append(colorEventStroke).append("\"")
                         .append(" stroke-width=\"").append(strokeWidth).append("\"")

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/export/SVGExporter.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/export/SVGExporter.java
@@ -40,6 +40,10 @@ public class SVGExporter {
                 .append("\" height=\"")
                 .append(model.height).append("\">\n");
 
+        // TODO extract colors to constant or configurable field
+        final String colorFillGateway ="gold";
+        final String colorStrokeGateway ="GoldenRod";
+
         for (DisplayFlowNode flowNode : model.flowNodes) {
             DisplayDimension flowNodeDimension = flowNode.dimension;
             DisplayLabel label = flowNode.label;
@@ -63,20 +67,33 @@ public class SVGExporter {
                 // TODO improve cx/cy management
                 //<ellipse cx="201" cy="291" rx="15" ry="15" fill="white" stroke="black" stroke-width="2" pointer-events="all"></ellipse>
                 //                  <ellipse cx="752" cy="260" rx="16" ry="16" fill="white" stroke="black" stroke-width="5" pointer-events="all"></ellipse>
-                content.append("<ellipse ")
-                        .append("cx=\"").append(flowNodeDimension.x).append("\" ")
-                        .append("cy=\"").append(flowNodeDimension.y).append("\" ")
-                        .append("rx=\"").append(flowNodeDimension.width).append("\" ")
-                        .append("ry=\"").append(flowNodeDimension.height).append("\" ")
+                content.append("<ellipse")
+                        .append(" cx=\"").append(flowNodeDimension.x).append("\"")
+                        .append(" cy=\"").append(flowNodeDimension.y).append("\"")
+                        .append(" rx=\"").append(flowNodeDimension.width).append("\"")
+                        .append(" ry=\"").append(flowNodeDimension.height).append("\"")
                         // TODO extract colors
-                        .append("fill=\"white\" stroke=\"black\" stroke-width=\"").append(strokeWidth).append("\" ")
-                        .append("pointer-events=\"all\" />\n")
+                        .append(" fill=\"white\" stroke=\"black\"")
+                        .append(" stroke-width=\"").append(strokeWidth).append("\"")
+                        .append(" pointer-events=\"all\"")
+                        .append(" />\n")
                 //
                 ;
-
             } else if (flowNode.type == ShapeType.GATEWAY) {
                 log.debug("Exporting gateway {}", flowNode.bpmnElementId);
-
+                // TODO gateway should be a rhombus/diamond instead of a rectangle
+                content.append("<rect");
+                content.append(" x=\"").append(flowNodeDimension.x).append("\"");
+                content.append(" y=\"").append(flowNodeDimension.y).append("\"");
+                content.append(" width=\"").append(flowNodeDimension.width).append("\"");
+                content.append(" height=\"").append(flowNodeDimension.height).append("\"");
+                content.append(" rx=\"").append(flowNode.rx).append("\"");
+                content.append(" fill=\"").append(colorFillGateway).append("\"")
+                        .append(" stroke=\"").append(colorStrokeGateway).append("\"")
+                        .append(" stroke-width=\"").append(strokeWidth).append("\"")
+                        .append(" />\n")
+                //
+                ;
             }
 
             content.append("<text x=\"").append(labelDimension.x);

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/model/Shape.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/model/Shape.java
@@ -39,4 +39,3 @@ public class Shape {
     }
 
 }
-

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/model/Shape.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/model/Shape.java
@@ -30,12 +30,12 @@ public class Shape {
     private final String name;
     private final ShapeType type;
 
-    public Shape(String name) {
-        this(name, name, ACTIVITY);
+    public static Shape shape(String name) {
+        return new Shape(name, name, ACTIVITY);
     }
 
-    public static Shape shape(String name) {
-        return new Shape(name);
+    public static Shape shape(String id, String name) {
+        return new Shape(id, name, ACTIVITY);
     }
 
 }

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/model/ShapeType.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/model/ShapeType.java
@@ -15,28 +15,6 @@
  */
 package io.process.analytics.tools.bpmn.generator.model;
 
-import static io.process.analytics.tools.bpmn.generator.model.ShapeType.ACTIVITY;
-
-import lombok.Builder;
-import lombok.Data;
-import lombok.RequiredArgsConstructor;
-
-@Data
-@Builder(toBuilder = true)
-@RequiredArgsConstructor
-public class Shape {
-
-    private final String id; // the bpmnElement id
-    private final String name;
-    private final ShapeType type;
-
-    public Shape(String name) {
-        this(name, name, ACTIVITY);
-    }
-
-    public static Shape shape(String name) {
-        return new Shape(name);
-    }
-
+public enum ShapeType {
+    ACTIVITY, EVENT, GATEWAY;
 }
-

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/algo/ShapeSorterTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/algo/ShapeSorterTest.java
@@ -1,25 +1,42 @@
+/*
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.process.analytics.tools.bpmn.generator.algo;
 
 import static io.process.analytics.tools.bpmn.generator.model.Edge.edge;
 import static io.process.analytics.tools.bpmn.generator.model.Edge.revertedEdge;
+import static io.process.analytics.tools.bpmn.generator.model.Shape.shape;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import org.junit.jupiter.api.Test;
+
+import io.process.analytics.tools.bpmn.generator.model.Diagram;
 import io.process.analytics.tools.bpmn.generator.model.Edge;
 import io.process.analytics.tools.bpmn.generator.model.Shape;
-import io.process.analytics.tools.bpmn.generator.model.Diagram;
-import org.junit.jupiter.api.Test;
 
 class ShapeSorterTest {
 
-    private ShapeSorter shapeSorter = new ShapeSorter();
+    private final ShapeSorter shapeSorter = new ShapeSorter();
 
-    Shape start = new Shape("start");
-    Shape step1 = new Shape("step1");
-    Shape step2 = new Shape("step2");
-    Shape step3 = new Shape("step3");
-    Shape step4 = new Shape("step4");
-    Shape step5 = new Shape("step5");
-    Shape end = new Shape("end");
+    private final Shape start = shape("start");
+    private final Shape step1 = shape("step1");
+    private final Shape step2 = shape("step2");
+    private final Shape step3 = shape("step3");
+    private final Shape step4 = shape("step4");
+    private final Shape step5 = shape("step5");
+    private final Shape end = shape("end");
 
     @Test
     void should_sort_2_shapes() {

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/converter/BpmnToAlgoModelConverterTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/converter/BpmnToAlgoModelConverterTest.java
@@ -13,14 +13,15 @@
 package io.process.analytics.tools.bpmn.generator.converter;
 
 
-import io.process.analytics.tools.bpmn.generator.internal.generated.model.TDefinitions;
-import io.process.analytics.tools.bpmn.generator.model.Shape;
-import io.process.analytics.tools.bpmn.generator.model.Diagram;
-import org.junit.jupiter.api.Test;
-
 import static io.process.analytics.tools.bpmn.generator.internal.SemanticTest.definitionsFromBpmnFile;
 import static io.process.analytics.tools.bpmn.generator.model.Edge.edge;
+import static io.process.analytics.tools.bpmn.generator.model.Shape.shape;
 import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+import io.process.analytics.tools.bpmn.generator.internal.generated.model.TDefinitions;
+import io.process.analytics.tools.bpmn.generator.model.Diagram;
 
 class BpmnToAlgoModelConverterTest {
 
@@ -44,9 +45,9 @@ class BpmnToAlgoModelConverterTest {
         Diagram diagram = new BpmnToAlgoModelConverter().toAlgoModel(definitions);
 
         assertThat(diagram.getShapes()).containsOnly(
-                new Shape("startEvent_1", "Start Event"),
-                new Shape("task_1", "Task 1"),
-                new Shape("endEvent_1", "End Event"));
+                shape("startEvent_1", "Start Event"),
+                shape("task_1", "Task 1"),
+                shape("endEvent_1", "End Event"));
         assertThat(diagram.getEdges()).containsOnly(
                 edge("sequenceFlow_1", "startEvent_1", "task_1"),
                 edge("sequenceFlow_2", "task_1", "endEvent_1"));

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/converter/BpmnToAlgoModelConverterTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/converter/BpmnToAlgoModelConverterTest.java
@@ -12,16 +12,18 @@
  */
 package io.process.analytics.tools.bpmn.generator.converter;
 
-
 import static io.process.analytics.tools.bpmn.generator.internal.SemanticTest.definitionsFromBpmnFile;
 import static io.process.analytics.tools.bpmn.generator.model.Edge.edge;
-import static io.process.analytics.tools.bpmn.generator.model.Shape.shape;
+import static io.process.analytics.tools.bpmn.generator.model.ShapeType.*;
 import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
 
-import io.process.analytics.tools.bpmn.generator.internal.generated.model.TDefinitions;
+import io.process.analytics.tools.bpmn.generator.internal.generated.model.*;
 import io.process.analytics.tools.bpmn.generator.model.Diagram;
+import io.process.analytics.tools.bpmn.generator.model.Shape;
 
 class BpmnToAlgoModelConverterTest {
 
@@ -45,12 +47,41 @@ class BpmnToAlgoModelConverterTest {
         Diagram diagram = new BpmnToAlgoModelConverter().toAlgoModel(definitions);
 
         assertThat(diagram.getShapes()).containsOnly(
-                shape("startEvent_1", "Start Event"),
-                shape("task_1", "Task 1"),
-                shape("endEvent_1", "End Event"));
+                new Shape("startEvent_1", "Start Event", EVENT),
+                new Shape("task_1", "Task 1", ACTIVITY),
+                new Shape("endEvent_1", "End Event", EVENT));
         assertThat(diagram.getEdges()).containsOnly(
                 edge("sequenceFlow_1", "startEvent_1", "task_1"),
                 edge("sequenceFlow_2", "task_1", "endEvent_1"));
+    }
+
+    @Test
+    void should_convert_activities_to_shape() {
+        assertThat(toShape(new TUserTask(), new TSendTask(), new TSubProcess()))
+                .containsOnly(new Shape("bpmn_id", "bpmn_name", ACTIVITY));
+    }
+
+    private static Stream<Shape> toShape(TFlowNode... flowNodes) {
+        return Stream.of(flowNodes).map(BpmnToAlgoModelConverterTest::setBaseFields)
+                .map(BpmnToAlgoModelConverter::toShape);
+    }
+
+    private static TFlowNode setBaseFields(TFlowNode flowNode) {
+        flowNode.setId("bpmn_id");
+        flowNode.setName("bpmn_name");
+        return flowNode;
+    }
+
+    @Test
+    void should_convert_events_to_shape() {
+        assertThat(toShape(new TStartEvent(), new TIntermediateCatchEvent(), new TEndEvent()))
+                .containsOnly(new Shape("bpmn_id", "bpmn_name", EVENT));
+    }
+
+    @Test
+    void should_convert_gateways_to_shape() {
+        assertThat(toShape(new TParallelGateway(), new TComplexGateway()))
+                .containsOnly(new Shape("bpmn_id", "bpmn_name", GATEWAY));
     }
 
 }

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/model/GridTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/model/GridTest.java
@@ -1,6 +1,7 @@
 package io.process.analytics.tools.bpmn.generator.model;
 
 import static io.process.analytics.tools.bpmn.generator.model.Position.position;
+import static io.process.analytics.tools.bpmn.generator.model.Shape.shape;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
@@ -8,9 +9,9 @@ import org.junit.jupiter.api.Test;
 class GridTest {
 
     private Grid grid = new Grid();
-    private Shape nodeA = Shape.shape("a");
-    private Shape nodeB = Shape.shape("b");
-    private Shape nodeC = Shape.shape("c");
+    private Shape nodeA = shape("a");
+    private Shape nodeB = shape("b");
+    private Shape nodeC = shape("c");
 
     @Test
     public void should_move_element_when_adding_row_after() {

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/model/GridTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/model/GridTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2020 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.process.analytics.tools.bpmn.generator.model;
 
 import static io.process.analytics.tools.bpmn.generator.model.Position.position;
@@ -8,10 +23,10 @@ import org.junit.jupiter.api.Test;
 
 class GridTest {
 
-    private Grid grid = new Grid();
-    private Shape nodeA = shape("a");
-    private Shape nodeB = shape("b");
-    private Shape nodeC = shape("c");
+    private final Grid grid = new Grid();
+    private final Shape nodeA = shape("a");
+    private final Shape nodeB = shape("b");
+    private final Shape nodeC = shape("c");
 
     @Test
     public void should_move_element_when_adding_row_after() {


### PR DESCRIPTION
This is an improvement of the initial implementation provided by #25
The dimensions of the gateways and events have been improved (width and height are the same), the label positions have also been adjusted for these BPMN elements


## Screenshots with [A.2.0.bpmn file from BPMN-MIWG](https://github.com/bpmn-miwg/bpmn-miwg-test-suite/blob/master/Reference/A.2.0.bpmn)
Notice that comparing to the #25 rendering, the sort algorithm has switched `Task 2` and `Task 4`, so the edge from `Task 2` to the `end event` overlaps the final gateway

**svg export**
It now identifies gateways and events

![pr35_commit_f3e2674e_A 2 0__svg_export](https://user-images.githubusercontent.com/27200110/82054099-b140fb80-96be-11ea-8402-95f0f74c70e4.png)


**bpmn-visualization-js (0.1.3 dev commit [1172325](https://github.com/process-analytics/bpmn-visualization-js/tree/1172325196f19cf601a0d022abe13836ce86a7a0))**
Label positions from the BPMN file are not used for rendering, the lib currently used arbitrary positions

![pr35_commit_f3e2674e_A 2 0__bpmn-visualisation-js@1172325196f19cf601a0d022abe13836ce86a7a0](https://user-images.githubusercontent.com/27200110/82054097-b140fb80-96be-11ea-8066-55cc7e496e34.png)

**demo.bpmn.io (bpmn-js@6.5.1)**
Label positions are taken from the BPMN file

![pr35_commit_f3e2674e_A 2 0__bpmn-io-demo@6 5 1](https://user-images.githubusercontent.com/27200110/82054095-b0a86500-96be-11ea-8e2c-7a6c686a55ed.png)




