### PR TITLE
feat(svg export): handle multi-lines label text

### DIFF
--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/export/SVGExporter.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/export/SVGExporter.java
@@ -112,17 +112,31 @@ public class SVGExporter {
                         .append(" />\n");
             }
 
+            String labelFillColor = "#374962";
+            String labelTextAnchor = "middle";
 
-            // TODO fill color depends on the shape type
-            // TODO seems not used to render the svg
-            String labelFillColor = "#374962"; // fill color for activities
             content.append("<text")
                     .append(" x=\"").append(labelDimension.x).append("\"")
                     .append(" y=\"").append(labelDimension.y).append("\"")
-                    .append(" text-anchor=\"middle\" font-size=\"").append(label.fontSize).append("\"")
-                    .append(" fill=\"").append(labelFillColor).append("\">")
-                    .append(label.text)
-                    .append("</text>\n");
+                    .append(" text-anchor=\"").append(labelTextAnchor).append("\"")
+                    .append(" font-size=\"").append(label.fontSize).append("\"")
+                    .append(" fill=\"").append(labelFillColor).append("\"")
+                    .append(">\n");
+            // handle multi-lines label text
+            String labelText = label.text;
+            boolean isFirstLabelTextLine = true;
+            for (String labelTextLine : labelText.split("\n")) {
+                content.append("  <tspan")
+                        .append(" x=\"").append(labelDimension.x).append("\"");
+                if (!isFirstLabelTextLine) {
+                    content.append(" dy=\"1.2em\"");
+                }
+                content.append(">")
+                        .append(labelTextLine)
+                        .append("</tspan>\n");
+                isFirstLabelTextLine = false;
+            }
+            content.append("</text>\n");
         }
         content.append("</svg>");
         return content.toString().getBytes();


### PR DESCRIPTION
Screenshots done with [A.2.0.bpmn file from BPMN-MIWG](https://github.com/bpmn-miwg/bpmn-miwg-test-suite/blob/master/Reference/A.2.0.bpmn)

**prior implementation**

![pr35_commit_f3e2674e_A 2 0__svg_export](https://user-images.githubusercontent.com/27200110/82054099-b140fb80-96be-11ea-8402-95f0f74c70e4.png)

**new implementation ef88c0c**

![pr39_commit_ef88c0c_A 2 0__svg_export](https://user-images.githubusercontent.com/27200110/82111560-59e66e00-9746-11ea-97d8-cde62ccb2c51.png)
