### PR TITLE
refactor(test): split app test using csv and bpmn inputs

### DIFF
--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/AppFromBpmnTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/AppFromBpmnTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.process.analytics.tools.bpmn.generator;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+
+import static io.process.analytics.tools.bpmn.generator.App.runApp;
+import static io.process.analytics.tools.bpmn.generator.AppTest.*;
+import static io.process.analytics.tools.bpmn.generator.internal.FileUtils.fileContent;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AppFromBpmnTest {
+
+    @Test
+    public void main_generates_bpmn_output_file_for_A_2_0() throws Exception {
+        runAndCheckBPMNGeneration("bpmn/A.2.0.bpmn.xml", "A.2.0_with_diagram.bpmn.xml");
+    }
+
+    @Test
+    public void main_generates_bpmn_output_file_for_A_2_1() throws Exception {
+        runAndCheckBPMNGeneration("bpmn/A.2.1.bpmn.xml", "A.2.1_with_diagram.bpmn.xml");
+    }
+
+    @Test
+    public void main_generates_svg_output_file() throws Exception {
+        String outputPath = outputPath("A.2.0_with_diagram.bpmn.svg");
+        runApp(input("bpmn/A.2.0.bpmn.xml"), "--output-type=SVG", "-o", outputPath);
+
+        assertSvgOutFile(outputPath);
+    }
+
+    @Test
+    public void main_generates_ascii_output_file() throws Exception {
+        String outputPath = outputPath("02-startEvent_task_endEvent-without-collaboration.bpmn.txt");
+        runApp(input("bpmn/02-startEvent_task_endEvent-without-collaboration.bpmn.xml"), "--output-type=ASCII", "-o", outputPath);
+
+        File asciiFile = new File(outputPath);
+        assertThat(asciiFile).exists().isFile();
+        assertThat(fileContent(asciiFile)).contains("+---");
+    }
+
+    // =================================================================================================================
+    // UTILS
+    // =================================================================================================================
+
+    private static void runAndCheckBPMNGeneration(String inputFileName, String outputFileName) throws IOException {
+        String outputPath = outputPath(outputFileName);
+        runApp(input(inputFileName), "-o", outputPath);
+        assertBpmnOutFile(outputPath);
+    }
+
+    private static String outputPath(String fileName) {
+        return "target/test/output/AppFromBpmnTest/" + fileName;
+    }
+
+}

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/AppFromCsvTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/AppFromCsvTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 Bonitasoft S.A.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.process.analytics.tools.bpmn.generator;
+
+import org.junit.jupiter.api.Test;
+
+import static io.process.analytics.tools.bpmn.generator.App.runApp;
+import static io.process.analytics.tools.bpmn.generator.AppTest.assertBpmnOutFile;
+import static io.process.analytics.tools.bpmn.generator.AppTest.input;
+
+public class AppFromCsvTest {
+
+    @Test
+    public void main_generates_bpmn_with_simple_discovery_data() throws Exception {
+        String outputPath = outputPath("from_simple_csv_diagram.bpmn.xml");
+        runApp("--input-type=CSV", "--output", outputPath, input("csv/PatientsProcess/nodeSimple.csv"), input("csv/PatientsProcess/edgeSimple.csv"));
+
+        assertBpmnOutFile(outputPath);
+    }
+
+    @Test
+    public void main_generates_bpmn_with_gateways() throws Exception {
+        String outputPath = outputPath("from_csv_with_gateways.bpmn");
+        runApp("--input-type=CSV", "--output", outputPath, input("csv/PatientsProcess/gateway_node_simple.csv"), input("csv/PatientsProcess/gateway_edge_simple.csv"));
+
+        assertBpmnOutFile(outputPath);
+    }
+
+    @Test
+    public void main_generates_bpmn_with_patients_process_discovery_data() throws Exception {
+        String outputPath = outputPath("from_patients_csv_diagram.bpmn.xml");
+        runApp("--input-type=CSV", "--output", outputPath, input("csv/PatientsProcess/node.csv"), input("csv/PatientsProcess/edge.csv"));
+
+        assertBpmnOutFile(outputPath);
+    }
+
+    // =================================================================================================================
+    // UTILS
+    // =================================================================================================================
+
+    private static String outputPath(String fileName) {
+        return "target/test/output/AppFromCsvTest/" + fileName;
+    }
+
+}

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/AppTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/AppTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 public class AppTest {
 
     @Test
-    public void main_fail_on_unexisting_input_file() throws Exception {
+    public void main_fail_on_non_existing_input_file() throws Exception {
         int returnCode = runApp("input");
 
         assertThat(returnCode).isEqualTo(2);
@@ -35,92 +35,29 @@ public class AppTest {
 
     @Test
     public void main_fail_on_wrong_export_type() throws Exception {
-
         int returnCode = runApp("input", "--output-type", "unknown_export_type");
 
         assertThat(returnCode).isEqualTo(2);
-    }
-
-    @Test
-    public void main_generates_bpmn_output_file_for_A_2_0() throws Exception {
-        checkBPMNGeneration("bpmn/A.2.0.bpmn.xml", "A.2.0_with_diagram.bpmn.xml");
-    }
-
-    private void checkBPMNGeneration(String inputFileName, String outputFileName) throws IOException {
-        String outputPath = outputPath(outputFileName);
-        runApp(input(inputFileName), "-o", outputPath);
-
-        File bpmnFile = new File(outputPath);
-        assertThat(bpmnFile).exists().isFile();
-        assertThat(fileContent(bpmnFile)).contains("<semantic:definitions").contains("xmlns:semantic=\"http://www.omg.org/spec/BPMN/20100524/MODEL\"");
-    }
-
-    @Test
-    public void main_generates_bpmn_output_file_for_A_2_1() throws Exception {
-        checkBPMNGeneration("bpmn/A.2.1.bpmn.xml", "A.2.1_with_diagram.bpmn.xml");
-    }
-
-    @Test
-    public void main_generates_svg_output_file() throws Exception {
-        String outputPath = outputPath("A.2.0_with_diagram.bpmn.svg");
-        runApp(input("bpmn/A.2.0.bpmn.xml"), "--output-type=SVG", "-o", outputPath);
-
-        File svgFile = new File(outputPath);
-        assertThat(svgFile).exists().isFile();
-        assertThat(fileContent(svgFile)).contains("<svg xmlns=\"http://www.w3.org/2000/svg\"");
-    }
-
-    @Test
-    public void main_generates_ascii_output_file() throws Exception {
-        String outputPath = outputPath("02-startEvent_task_endEvent-without-collaboration.bpmn.txt");
-        runApp(input("bpmn/02-startEvent_task_endEvent-without-collaboration.bpmn.xml"), "--output-type=ASCII", "-o", outputPath);
-
-        File asciiFile = new File(outputPath);
-        assertThat(asciiFile).exists().isFile();
-        assertThat(fileContent(asciiFile)).contains("+---");
-    }
-
-    @Test
-    public void main_generates_bpmn_with_simple_discovery_data() throws Exception {
-        String outputPath = outputPath("from_simple_csv_diagram.bpmn.xml");
-        runApp("--input-type=CSV", "--output", outputPath, input("csv/PatientsProcess/nodeSimple.csv"), input("csv/PatientsProcess/edgeSimple.csv"));
-
-        assertOutFile(outputPath);
-    }
-
-    @Test
-    public void main_generates_bpmn_with_gateways() throws Exception {
-        String outputPath = outputPath("from_csv_with_gateways.bpmn");
-        runApp("--input-type=CSV", "--output", outputPath, input("csv/PatientsProcess/gateway_node_simple.csv"), input("csv/PatientsProcess/gateway_edge_simple.csv"));
-
-        assertOutFile(outputPath);
-    }
-
-    @Test
-    public void main_generates_bpmn_with_patients_process_discovery_data() throws Exception {
-        String outputPath = outputPath("from_patients_csv_diagram.bpmn.xml");
-        runApp("--input-type=CSV", "--output", outputPath, input("csv/PatientsProcess/node.csv"), input("csv/PatientsProcess/edge.csv"));
-
-        assertOutFile(outputPath);
     }
 
     // =================================================================================================================
     // UTILS
     // =================================================================================================================
 
-    private static void assertOutFile(String outputPath) throws IOException {
+    public static void assertBpmnOutFile(String outputPath) throws IOException {
         File bpmnFile = new File(outputPath);
         assertThat(bpmnFile).exists().isFile();
         assertThat(fileContent(bpmnFile)).contains("<semantic:definitions").contains("xmlns:semantic=\"http://www.omg.org/spec/BPMN/20100524/MODEL\"");
     }
 
-
-    private static String input(String fileName) {
-        return "src/test/resources/" + fileName;
+    public static void assertSvgOutFile(String outputPath) throws IOException {
+        File svgFile = new File(outputPath);
+        assertThat(svgFile).exists().isFile();
+        assertThat(fileContent(svgFile)).contains("<svg xmlns=\"http://www.w3.org/2000/svg\"");
     }
 
-    private static String outputPath(String fileName) {
-        return "target/test/output/AppTest/" + fileName;
+    public static String input(String fileName) {
+        return "src/test/resources/" + fileName;
     }
 
 }


### PR DESCRIPTION
This should clarify the purpose of each test class.
In addition
  - avoid duplication when checking the output bpmn file
  - introduce assertion to check output svg file