### PR TITLE
feat(waypoints): consider split/merge gateways for edge direction

### DIFF
--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/converter/AlgoToDisplayModelConverter.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/converter/AlgoToDisplayModelConverter.java
@@ -210,11 +210,11 @@ public class AlgoToDisplayModelConverter {
                         .stream()
                         .filter(p -> p.getY() == positionFrom.getY())
                         .anyMatch(p -> p.getX() == positionFrom.getX() + 1);
-                edgeDirection = shapeExistAtRightPositionFrom || (isGatewayAt(positionFrom) && !isGatewayAt(positionTo)) ? EdgeDirection.TopLeftToBottomRight_FirstVertical : EdgeDirection.TopLeftToBottomRight_FirstHorizontal;
+                edgeDirection = shapeExistAtRightPositionFrom || (isGatewayAt(positionFrom) && (!isGatewayAt(positionTo) || isGatewaySplitAt(positionTo))) ? EdgeDirection.TopLeftToBottomRight_FirstVertical : EdgeDirection.TopLeftToBottomRight_FirstHorizontal;
             }
             else {
                 if (isGatewayAt(positionFrom)) {
-                    edgeDirection = isGatewayAt(positionTo) ? EdgeDirection.BottomLeftToTopRight_FirstHorizontal : EdgeDirection.BottomLeftToTopRight_FirstVertical;
+                    edgeDirection = !isGatewaySplitAt(positionFrom) || isGatewayAt(positionTo) && !isGatewaySplitAt(positionTo) ? EdgeDirection.BottomLeftToTopRight_FirstHorizontal : EdgeDirection.BottomLeftToTopRight_FirstVertical;
                 } else {
                     boolean shapeExistAbovePositionFrom = grid.getPositions()
                         .stream()
@@ -244,6 +244,10 @@ public class AlgoToDisplayModelConverter {
 
     private static boolean isGatewayAt(Position position) {
         return ShapeType.GATEWAY.equals(position.getShapeType());
+    }
+
+    private static boolean isGatewaySplitAt(Position position) {
+        return isGatewayAt(position) && position.isSplitGateway();
     }
 
     // visible for testing

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/converter/BpmnToAlgoModelConverter.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/converter/BpmnToAlgoModelConverter.java
@@ -55,12 +55,14 @@ public class BpmnToAlgoModelConverter {
     // visible for testing
     static Shape toShape(TFlowElement flowNode) {
         ShapeType shapeType = ACTIVITY;
+        boolean isSplitGateway = false;
         if (flowNode instanceof TGateway) {
             shapeType = GATEWAY;
+            isSplitGateway = ((TGateway) flowNode).getOutgoing().size() > 1;
         } else if (flowNode instanceof TEvent) {
             shapeType = EVENT;
         }
-        return new Shape(flowNode.getId(), flowNode.getName(), shapeType);
+        return new Shape(flowNode.getId(), flowNode.getName(), shapeType, isSplitGateway);
     }
 
 }

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/model/Position.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/model/Position.java
@@ -9,10 +9,12 @@ public class Position {
     private final String shape;
     private final String shapeName;
     private final ShapeType shapeType;
+    private final boolean isSplitGateway;
+
     private final int x;
     private final int y;
 
     public static Position position(Shape shape, int x, int y) {
-        return new Position(shape.getId(), shape.getName(), shape.getType(), x, y);
+        return new Position(shape.getId(), shape.getName(), shape.getType(), shape.isSplitGateway(), x, y);
     }
 }

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/model/Shape.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/model/Shape.java
@@ -29,13 +29,17 @@ public class Shape {
     private final String id; // the bpmnElement id
     private final String name;
     private final ShapeType type;
+    private final boolean isSplitGateway;
 
     public static Shape shape(String name) {
-        return new Shape(name, name, ACTIVITY);
+        return new Shape(name, name, ACTIVITY, false);
     }
 
     public static Shape shape(String id, String name) {
-        return new Shape(id, name, ACTIVITY);
+        return new Shape(id, name, ACTIVITY, false);
     }
 
+    public static Shape shape(String id, String name, ShapeType type) {
+        return new Shape(id, name, type, false);
+    }
 }

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/AppFromBpmnTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/AppFromBpmnTest.java
@@ -28,18 +28,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class AppFromBpmnTest {
 
     @Test
-    public void main_generates_bpmn_output_file_for_A_2_0() throws Exception {
+    public void main_generates_output_files_for_A_2_0() throws Exception {
         runAndCheckBPMNGeneration("bpmn/A.2.0.bpmn.xml", "A.2.0_with_diagram.bpmn.xml");
-    }
-
-    @Test
-    public void main_generates_bpmn_output_file_for_A_2_1() throws Exception {
-        runAndCheckBPMNGeneration("bpmn/A.2.1.bpmn.xml", "A.2.1_with_diagram.bpmn.xml");
-    }
-
-    @Test
-    public void main_generates_svg_output_file_for_A_2_0() throws Exception {
         runAndCheckSvgGeneration("bpmn/A.2.0.bpmn.xml", "A.2.0_with_diagram.bpmn.svg");
+    }
+
+    @Test
+    public void main_generates_output_files_for_A_2_1() throws Exception {
+        runAndCheckBPMNGeneration("bpmn/A.2.1.bpmn.xml", "A.2.1_with_diagram.bpmn.xml");
+        runAndCheckSvgGeneration("bpmn/A.2.1.bpmn.xml", "A.2.1_with_diagram.bpmn.svg");
     }
 
     @Test

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/AppFromBpmnTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/AppFromBpmnTest.java
@@ -29,14 +29,12 @@ public class AppFromBpmnTest {
 
     @Test
     public void main_generates_output_files_for_A_2_0() throws Exception {
-        runAndCheckBPMNGeneration("bpmn/A.2.0.bpmn.xml", "A.2.0_with_diagram.bpmn.xml");
-        runAndCheckSvgGeneration("bpmn/A.2.0.bpmn.xml", "A.2.0_with_diagram.bpmn.svg");
+        runAndCheckBpmnAndSvgGeneration("bpmn/A.2.0.bpmn.xml", "A.2.0_with_diagram.bpmn");
     }
 
     @Test
     public void main_generates_output_files_for_A_2_1() throws Exception {
-        runAndCheckBPMNGeneration("bpmn/A.2.1.bpmn.xml", "A.2.1_with_diagram.bpmn.xml");
-        runAndCheckSvgGeneration("bpmn/A.2.1.bpmn.xml", "A.2.1_with_diagram.bpmn.svg");
+        runAndCheckBpmnAndSvgGeneration("bpmn/A.2.1.bpmn.xml", "A.2.1_with_diagram.bpmn");
     }
 
     @Test
@@ -51,21 +49,26 @@ public class AppFromBpmnTest {
 
     @Test
     public void main_generates_output_files_for_waypoints_positions_for_gateways() throws Exception {
-        runAndCheckBPMNGeneration("bpmn/waypoints-positions-gateways.bpmn.xml", "waypoints-positions_with_diagram.bpmn.xml");
-        runAndCheckSvgGeneration("bpmn/waypoints-positions-gateways.bpmn.xml", "waypoints-positions_with_diagram.bpmn.svg");
+        runAndCheckBpmnAndSvgGeneration("bpmn/waypoints-positions-gateways.bpmn.xml",
+                "waypoints-positions_with_diagram.bpmn");
     }
 
     @Test
     public void main_generates_output_files_for_waypoints_positions_for_gateways_split_merge() throws Exception {
-        runAndCheckBPMNGeneration("bpmn/waypoints-positions-gateways_split_merge.bpmn.xml", "waypoints-positions-gateways_split_merge.bpmn.xml");
-        runAndCheckSvgGeneration("bpmn/waypoints-positions-gateways_split_merge.bpmn.xml", "waypoints-positions-gateways_split_merge.bpmn.svg");
+        runAndCheckBpmnAndSvgGeneration("bpmn/waypoints-positions-gateways_split_merge.bpmn.xml",
+                "waypoints-positions-gateways_split_merge.bpmn");
     }
 
     // =================================================================================================================
     // UTILS
     // =================================================================================================================
 
-    private static void runAndCheckBPMNGeneration(String inputFileName, String outputFileName) throws IOException {
+    private static void runAndCheckBpmnAndSvgGeneration(String inputFileName, String outputFileBaseName) throws IOException {
+        runAndCheckBpmnGeneration(inputFileName, outputFileBaseName + ".xml");
+        runAndCheckSvgGeneration(inputFileName, outputFileBaseName + ".svg");
+    }
+
+    private static void runAndCheckBpmnGeneration(String inputFileName, String outputFileName) throws IOException {
         String outputPath = outputPath(outputFileName);
         runApp(input(inputFileName), "-o", outputPath);
         assertBpmnOutFile(outputPath);

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/converter/AlgoToDisplayModelConverterTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/converter/AlgoToDisplayModelConverterTest.java
@@ -20,6 +20,7 @@ import io.process.analytics.tools.bpmn.generator.model.ShapeType;
 import org.junit.jupiter.api.Test;
 
 import static io.process.analytics.tools.bpmn.generator.converter.AlgoToDisplayModelConverter.EdgeDirection.*;
+import static io.process.analytics.tools.bpmn.generator.model.Shape.shape;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class AlgoToDisplayModelConverterTest {
@@ -93,29 +94,49 @@ class AlgoToDisplayModelConverterTest {
     // =================================================================================================================
 
     @Test
-    public void computeEdgeDirection_from_gateway_on_bottom_left_to_on_top_right() {
-        //  +-----------------+
-        //  |            to   |
-        //  | from-gw         |
-        //  +-----------------+
-        assertThat(computeEdgeDirection(positionGateway(10, 100), position(50, 50)))
+    public void computeEdgeDirection_from_split_gateway_on_bottom_left_to_on_top_right() {
+        //  +---------------------+
+        //  |                  to |
+        //  | from-gw-split       |
+        //  +---------------------+
+        assertThat(computeEdgeDirection(positionGatewaySplit(10, 100), position(50, 50)))
                 .isEqualTo(BottomLeftToTopRight_FirstVertical);
     }
 
     @Test
-    public void computeEdgeDirection_from_gateway_on_bottom_left_to_gateway_on_top_right() {
-        //  +-----------------+
-        //  |           to-gw |
-        //  | from-gw         |
-        //  +-----------------+
-        assertThat(computeEdgeDirection(positionGateway(10, 100), positionGateway(50, 50)))
+    public void computeEdgeDirection_from_merge_gateway_on_bottom_left_to_on_top_right() {
+        //  +---------------------+
+        //  |                  to |
+        //  | from-gw-merge       |
+        //  +---------------------+
+        assertThat(computeEdgeDirection(positionGatewayMerge(10, 100), position(50, 50)))
                 .isEqualTo(BottomLeftToTopRight_FirstHorizontal);
+    }
+
+    @Test
+    public void computeEdgeDirection_from_gateway_on_bottom_left_to_gateway_merge_on_top_right() {
+        //  +-----------------------+
+        //  |           to-gw-merge |
+        //  | from-gw               |  --> merge gateway
+        //  +-----------------------+
+        assertThat(computeEdgeDirection(positionGateway(10, 100), positionGatewayMerge(50, 50)))
+                .isEqualTo(BottomLeftToTopRight_FirstHorizontal);
+    }
+
+    @Test
+    public void computeEdgeDirection_from_gateway_on_bottom_left_to_gateway_split_on_top_right() {
+        //  +-----------------------------+
+        //  |                 to-gw-split |
+        //  | from-gw-split               |
+        //  +-----------------------------+
+        assertThat(computeEdgeDirection(positionGatewaySplit(10, 100), positionGatewaySplit(50, 50)))
+                .isEqualTo(BottomLeftToTopRight_FirstVertical);
     }
 
     @Test
     public void computeEdgeDirection_from_gateway_on_top_left_to_on_bottom_right() {
         //  +-----------------+
-        //  | from-gw         |
+        //  | from-gw         |  --> split gateway
         //  |            to   |
         //  +-----------------+
         assertThat(computeEdgeDirection(positionGateway(10, 10), position(50, 50)))
@@ -123,17 +144,27 @@ class AlgoToDisplayModelConverterTest {
     }
 
     @Test
-    public void computeEdgeDirection_from_gateway_on_top_left_to_on_bottom_right_is_gateway() {
-        //  +-----------------+
-        //  | from-gw         |
-        //  |           to-gw |
-        //  +-----------------+
-        assertThat(computeEdgeDirection(positionGateway(10, 10), positionGateway(50, 50)))
+    public void computeEdgeDirection_from_gateway_on_top_left_to_gateway_merge_on_bottom_right() {
+        //  +-----------------------+
+        //  | from-gw               |  --> split gateway
+        //  |           to-gw-merge |
+        //  +-----------------------+
+        assertThat(computeEdgeDirection(positionGateway(10, 10), positionGatewayMerge(50, 50)))
                 .isEqualTo(TopLeftToBottomRight_FirstHorizontal);
     }
 
     @Test
-    public void computeEdgeDirection_from_gateway_on_top_left_to_on_bottom_right_is_gateway_with_element_on_top_left() {
+    public void computeEdgeDirection_from_gateway_on_top_left_to_gateway_split_on_bottom_right() {
+        //  +-----------------------+
+        //  | from-gw               |  --> split gateway
+        //  |           to-gw-split |
+        //  +-----------------------+
+        assertThat(computeEdgeDirection(positionGateway(10, 10), positionGatewaySplit(50, 50)))
+                .isEqualTo(TopLeftToBottomRight_FirstVertical);
+    }
+
+    @Test
+    public void computeEdgeDirection_from_gateway_on_top_left_to_gateway_on_bottom_right_with_element_on_top_left() {
         //  +-----------------+
         //  | from-gw   elt   |
         //  |           to-gw |
@@ -146,7 +177,7 @@ class AlgoToDisplayModelConverterTest {
     public void computeEdgeDirection_from_on_top_left_to_gateway_on_bottom_right() {
         //  +-----------------+
         //  | from            |
-        //  |           to-gw |
+        //  |           to-gw |  --> merge gateway
         //  +-----------------+
         assertThat(computeEdgeDirection(position(10, 10), positionGateway(50, 50)))
                 .isEqualTo(TopLeftToBottomRight_FirstHorizontal);
@@ -155,7 +186,7 @@ class AlgoToDisplayModelConverterTest {
     @Test
     public void computeEdgeDirection_from_on_bottom_left_to_gateway_on_top_right() {
         //  +-----------------+
-        //  |          to-gw  |
+        //  |          to-gw  |  --> merge gateway
         //  | from            |
         //  +-----------------+
         assertThat(computeEdgeDirection(position(10, 100), positionGateway(50, 50)))
@@ -271,7 +302,15 @@ class AlgoToDisplayModelConverterTest {
     }
 
     private static Position positionGateway(int x, int y) {
-        return Position.position(new Shape(null, null, ShapeType.GATEWAY), x, y);
+        return Position.position(shape(null, null, ShapeType.GATEWAY), x, y);
+    }
+
+    private static Position positionGatewaySplit(int x, int y) {
+        return Position.position(new Shape(null, null, ShapeType.GATEWAY, true), x, y);
+    }
+
+    private static Position positionGatewayMerge(int x, int y) {
+        return Position.position(new Shape(null, null, ShapeType.GATEWAY, false), x, y);
     }
 
 }

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/converter/BpmnToAlgoModelConverterTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/converter/BpmnToAlgoModelConverterTest.java
@@ -14,6 +14,7 @@ package io.process.analytics.tools.bpmn.generator.converter;
 
 import static io.process.analytics.tools.bpmn.generator.internal.SemanticTest.definitionsFromBpmnFile;
 import static io.process.analytics.tools.bpmn.generator.model.Edge.edge;
+import static io.process.analytics.tools.bpmn.generator.model.Shape.shape;
 import static io.process.analytics.tools.bpmn.generator.model.ShapeType.*;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -47,9 +48,9 @@ class BpmnToAlgoModelConverterTest {
         Diagram diagram = new BpmnToAlgoModelConverter().toAlgoModel(definitions);
 
         assertThat(diagram.getShapes()).containsOnly(
-                new Shape("startEvent_1", "Start Event", EVENT),
-                new Shape("task_1", "Task 1", ACTIVITY),
-                new Shape("endEvent_1", "End Event", EVENT));
+                shape("startEvent_1", "Start Event", EVENT),
+                shape("task_1", "Task 1", ACTIVITY),
+                shape("endEvent_1", "End Event", EVENT));
         assertThat(diagram.getEdges()).containsOnly(
                 edge("sequenceFlow_1", "startEvent_1", "task_1"),
                 edge("sequenceFlow_2", "task_1", "endEvent_1"));
@@ -58,7 +59,7 @@ class BpmnToAlgoModelConverterTest {
     @Test
     void should_convert_activities_to_shape() {
         assertThat(toShape(new TUserTask(), new TSendTask(), new TSubProcess()))
-                .containsOnly(new Shape("bpmn_id", "bpmn_name", ACTIVITY));
+                .containsOnly(shape("bpmn_id", "bpmn_name", ACTIVITY));
     }
 
     private static Stream<Shape> toShape(TFlowNode... flowNodes) {
@@ -75,13 +76,13 @@ class BpmnToAlgoModelConverterTest {
     @Test
     void should_convert_events_to_shape() {
         assertThat(toShape(new TStartEvent(), new TIntermediateCatchEvent(), new TEndEvent()))
-                .containsOnly(new Shape("bpmn_id", "bpmn_name", EVENT));
+                .containsOnly(shape("bpmn_id", "bpmn_name", EVENT));
     }
 
     @Test
     void should_convert_gateways_to_shape() {
         assertThat(toShape(new TParallelGateway(), new TComplexGateway()))
-                .containsOnly(new Shape("bpmn_id", "bpmn_name", GATEWAY));
+                .containsOnly(shape("bpmn_id", "bpmn_name", GATEWAY));
     }
 
 }


### PR DESCRIPTION
The algorithm now better uses vertical
  - outgoing edges for split gateways
  - incoming edges for merge gateways

### Rendering evolutions


| diagram | Original diagram | Layout with PR #71 | Layout with PR #72 |
| ----- | ----- | ------ | -------- |
| test diagram | ![01_original](https://user-images.githubusercontent.com/27200110/120445520-fa76f280-c388-11eb-852f-167a51dccc9b.png) | ![02_old_implem](https://user-images.githubusercontent.com/27200110/120446616-01eacb80-c38a-11eb-8645-f8a167c0dd89.png) | ![03_new_implem](https://user-images.githubusercontent.com/27200110/120445543-019e0080-c389-11eb-9397-c6c240ef8577.png) |
| A.2.0 | ![A 2 0_01_original](https://user-images.githubusercontent.com/27200110/120452758-b8eb4500-c392-11eb-839a-96cae0edb651.png) | ![A 2 0_02_old](https://user-images.githubusercontent.com/27200110/120452760-b983db80-c392-11eb-828d-c323ff75430a.png) | ![A 2 0_03_new](https://user-images.githubusercontent.com/27200110/120452762-b983db80-c392-11eb-8123-6d04084b87a5.png) |



