### PR TITLE
feat(waypoints): improve join gateway on top-left to bottom-right

### DIFF
--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/converter/waypoint/WayPointsComputer.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/converter/waypoint/WayPointsComputer.java
@@ -252,7 +252,7 @@ public class WayPointsComputer {
                 direction = TopLeftToBottomRight;
                 boolean shapeExistAtRightPositionFrom = gridSearcher.isShapeExistAtRight(positionFrom);
                 orientation = shapeExistAtRightPositionFrom
-                        || (isGatewayAt(positionFrom) && (!isGatewayAt(positionTo) || isGatewaySplitAt(positionTo)))
+                        || (isGatewayAt(positionFrom) && isGatewaySplitAt(positionFrom) && (!isGatewayAt(positionTo) || isGatewaySplitAt(positionTo)))
                         ? Orientation.VerticalHorizontal
                         : Orientation.HorizontalVertical;
             } else {

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/converter/waypoint/WayPointsComputerTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/converter/waypoint/WayPointsComputerTest.java
@@ -260,17 +260,6 @@ class WayPointsComputerTest {
     // =================================================================================================================
 
     @Test
-    public void computeEdgeDirection_from_split_gateway_on_bottom_left_to_on_top_right() {
-        //  +---------------------+
-        //  |                  to |
-        //  | from-gw-split       |
-        //  +---------------------+
-        EdgeDirection edgeDirection = computeEdgeDirection(positionGatewaySplit(10, 100), position(50, 50));
-        assertThat(edgeDirection.direction).isEqualTo(BottomLeftToTopRight);
-        assertThat(edgeDirection.orientation).isEqualTo(VerticalHorizontal);
-    }
-
-    @Test
     public void computeEdgeDirection_from_join_gateway_on_bottom_left_to_on_top_right() {
         //  +---------------------+
         //  |                  to |
@@ -279,6 +268,28 @@ class WayPointsComputerTest {
         EdgeDirection edgeDirection = computeEdgeDirection(positionGatewayJoin(10, 100), position(50, 50));
         assertThat(edgeDirection.direction).isEqualTo(BottomLeftToTopRight);
         assertThat(edgeDirection.orientation).isEqualTo(HorizontalVertical);
+    }
+
+    @Test
+    public void computeEdgeDirection_from_join_gateway_on_top_left_to_on_bottom_right() {
+        //  +---------------------+
+        //  | from-gw-join        |
+        //  |                  to |
+        //  +---------------------+
+        EdgeDirection edgeDirection = computeEdgeDirection(positionGatewayJoin(1, 1), position(5, 5));
+        assertThat(edgeDirection.direction).isEqualTo(TopLeftToBottomRight);
+        assertThat(edgeDirection.orientation).isEqualTo(HorizontalVertical);
+    }
+
+    @Test
+    public void computeEdgeDirection_from_split_gateway_on_bottom_left_to_on_top_right() {
+        //  +---------------------+
+        //  |                  to |
+        //  | from-gw-split       |
+        //  +---------------------+
+        EdgeDirection edgeDirection = computeEdgeDirection(positionGatewaySplit(10, 100), position(50, 50));
+        assertThat(edgeDirection.direction).isEqualTo(BottomLeftToTopRight);
+        assertThat(edgeDirection.orientation).isEqualTo(VerticalHorizontal);
     }
 
     @Test


### PR DESCRIPTION
**Depends on #84**

This ensures that we follow the same rule for outgoing edges from join gateway:
always output horizontally.

### Screenshots

**Note**: the change is visible between the `gateways_merge_2` join gateway and the `Review Request` task (in the center of the image)

![prior_change](https://user-images.githubusercontent.com/27200110/121052215-71155500-c7ba-11eb-9917-0a09dec4c893.png)

![with_change](https://user-images.githubusercontent.com/27200110/121148422-0d366f00-c842-11eb-8347-55f172f73f51.png)
