### PR TITLE
feat: better identify incoming and outgoing edges

### DIFF
--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/converter/Configuration.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/converter/Configuration.java
@@ -16,4 +16,6 @@ public class Configuration {
     // TODO this should be configurable for by the client code
     public static final int CELL_WIDTH = 200;
     public static final int CELL_HEIGHT = 100;
+
+    public static final int EDGE_OUTGOING_FIRST_HORIZONTAL_SEGMENT_LENGTH = 20;
 }

--- a/java/src/main/java/io/process/analytics/tools/bpmn/generator/converter/waypoint/WayPointsConverter.java
+++ b/java/src/main/java/io/process/analytics/tools/bpmn/generator/converter/waypoint/WayPointsConverter.java
@@ -16,6 +16,7 @@
 package io.process.analytics.tools.bpmn.generator.converter.waypoint;
 
 import static io.process.analytics.tools.bpmn.generator.converter.Configuration.CELL_HEIGHT;
+import static io.process.analytics.tools.bpmn.generator.converter.Configuration.EDGE_OUTGOING_FIRST_HORIZONTAL_SEGMENT_LENGTH;
 import static io.process.analytics.tools.bpmn.generator.converter.waypoint.Orientation.*;
 
 import java.util.ArrayList;
@@ -64,10 +65,11 @@ public class WayPointsConverter {
                     wayPoints.add(new DisplayPoint(to.x, from.y));
                     wayPoints.add(to);
                 } else if (orientation == VerticalHorizontal) {
-                    DisplayPoint from = edgeTerminalPoints.centerTop(dimensionFrom);
+                    DisplayPoint from = edgeTerminalPoints.rightMiddle(dimensionFrom);
                     DisplayPoint to = edgeTerminalPoints.leftMiddle(dimensionTo);
                     wayPoints.add(from);
-                    wayPoints.add(new DisplayPoint(from.x, to.y));
+                    wayPoints.add(new DisplayPoint(from.x + EDGE_OUTGOING_FIRST_HORIZONTAL_SEGMENT_LENGTH, from.y));
+                    wayPoints.add(new DisplayPoint(from.x + EDGE_OUTGOING_FIRST_HORIZONTAL_SEGMENT_LENGTH, to.y));
                     wayPoints.add(to);
                 }
                 break;
@@ -94,10 +96,11 @@ public class WayPointsConverter {
                     wayPoints.add(new DisplayPoint(to.x, from.y));
                     wayPoints.add(to);
                 } else if (orientation == VerticalHorizontal) {
-                    DisplayPoint from = edgeTerminalPoints.centerBottom(dimensionFrom);
+                    DisplayPoint from = edgeTerminalPoints.rightMiddle(dimensionFrom);
                     DisplayPoint to = edgeTerminalPoints.leftMiddle(dimensionTo);
                     wayPoints.add(from);
-                    wayPoints.add(new DisplayPoint(from.x, to.y));
+                    wayPoints.add(new DisplayPoint(from.x + EDGE_OUTGOING_FIRST_HORIZONTAL_SEGMENT_LENGTH, from.y));
+                    wayPoints.add(new DisplayPoint(from.x + EDGE_OUTGOING_FIRST_HORIZONTAL_SEGMENT_LENGTH, to.y));
                     wayPoints.add(to);
                 }
                 break;
@@ -139,13 +142,15 @@ public class WayPointsConverter {
                                                                     DisplayDimension dimensionFrom, DisplayDimension dimensionTo) {
         log.debug("Bend configuration: {}", bendConfiguration);
 
-        DisplayPoint from = bendConfiguration.direction == BendDirection.BOTTOM ? edgeTerminalPoints.centerBottom(dimensionFrom): edgeTerminalPoints.centerTop(dimensionFrom);
+        DisplayPoint from = edgeTerminalPoints.rightMiddle(dimensionFrom);
         DisplayPoint to = bendConfiguration.direction == BendDirection.BOTTOM ? edgeTerminalPoints.centerBottom(dimensionTo): edgeTerminalPoints.centerTop(dimensionTo);
-        int bendPointY = from.y + bendConfiguration.direction.numericFactor() * bendConfiguration.offset * CELL_HEIGHT;
+        int bendPointY = from.y + bendConfiguration.direction.numericFactor() * ( dimensionFrom.height / 2 + bendConfiguration.offset * CELL_HEIGHT);
 
         List<DisplayPoint> wayPoints = new ArrayList<>();
         wayPoints.add(from);
-        wayPoints.add(new DisplayPoint(from.x, bendPointY));
+        DisplayPoint intermediate = new DisplayPoint(from.x + EDGE_OUTGOING_FIRST_HORIZONTAL_SEGMENT_LENGTH, from.y);
+        wayPoints.add(intermediate);
+        wayPoints.add(new DisplayPoint(intermediate.x, bendPointY));
         wayPoints.add(new DisplayPoint(to.x, bendPointY));
         wayPoints.add(to);
         return wayPoints;


### PR DESCRIPTION
Previously, it was possible to have vertically incoming and vertically outgoing edges on the same shape.
This made it difficult to distinguish one from the other.
This usually happened on gateways.

To easily identify the two edge types, only incoming edges can now be connected vertically.
Outgoing edges always start with a small horizontal segment.

## Screenshots

### BPMN

![PR_128_gateways](https://github.com/user-attachments/assets/6f44e8fd-9ae2-4099-95d6-3dda1d62fde0)

### SVG

![waypoints-positions-gateways bpmn xml](https://github.com/user-attachments/assets/c03a8eea-f184-4ce4-aa64-9b6e1063d807)

