### PR TITLE
feat: display arrow in SVG export

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -58,6 +58,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <version>3.25.3</version>

--- a/java/src/test/java/io/process/analytics/tools/bpmn/generator/export/SVGExporterTest.java
+++ b/java/src/test/java/io/process/analytics/tools/bpmn/generator/export/SVGExporterTest.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2024 Bonitasoft S.A.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.process.analytics.tools.bpmn.generator.export;
+
+import io.process.analytics.tools.bpmn.generator.converter.waypoint.Direction;
+import io.process.analytics.tools.bpmn.generator.model.display.DisplayPoint;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SVGExporterTest {
+
+    @ParameterizedTest
+    @MethodSource("provideWaypointsForDirectionDetection")
+    void detect_last_segment_direction(List<DisplayPoint> waypoints, Direction expectedDirection) {
+        var direction = SVGExporter.detectLastSegmentDirection(waypoints);
+        assertThat(direction).isEqualTo(expectedDirection);
+    }
+
+    private static Stream<Arguments> provideWaypointsForDirectionDetection() {
+        return Stream.of(
+                Arguments.of(List.of(new DisplayPoint(0, 37), new DisplayPoint(10, 37)), Direction.LeftToRight),
+                Arguments.of(List.of(new DisplayPoint(40, 58), new DisplayPoint(10, 58)), Direction.RightToLeft),
+                Arguments.of(List.of(new DisplayPoint(13, 73), new DisplayPoint(13, 137)), Direction.TopToBottom),
+                Arguments.of(List.of(new DisplayPoint(33, 73), new DisplayPoint(33, 37)), Direction.BottomToTop)
+        );
+    }
+
+}
+


### PR DESCRIPTION
Previously, a simple circle was displayed to identify the target shape.
Using an arrow better match the usual BPMN rendering

## Screenshots

![waypoints-positions-cycle_01_simple bpmn xml](https://github.com/user-attachments/assets/5f915e2a-8683-4668-92d7-3b5b59323b9a)
