### PR TITLE
ci: fix checkout in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           git config --local user.name "${{ vars.PA_BOT_NAME }}"
           git config pull.rebase true
       - name: Checkout default branch
-        run: git checkout main && git pull --tags
+        run: git checkout master && git pull --tags
 
       - uses: actions/setup-java@v4
         with:


### PR DESCRIPTION

### Notes

See during the first attempt to create the `0.2.0` release.

https://github.com/process-analytics/bpmn-layout-generators/actions/runs/10521246640/job/29151560563#step:5:1
> Run git checkout main && git pull --tags
error: pathspec 'main' did not match any file(s) known to git
Error: Process completed with exit code 1.